### PR TITLE
Correct Git hosting provider capitalization

### DIFF
--- a/docs/articles/move-git-repos-between-team-projects.md
+++ b/docs/articles/move-git-repos-between-team-projects.md
@@ -32,7 +32,7 @@ As shown, we need to move the MigrationDemo repo, from the FabrikamOld to the ne
 You have 2 options as outlined below. Import functionality is easier, but is only available in VSTS and TFS 2017 Update 1 and above.  
 
 ### Use Import Git repository functionality
-Using Import Repository, you can import a Git repository to your team project from TFS/VSTS or any other Git source code provider like Github. 
+Using Import Repository, you can import a Git repository to your team project from TFS/VSTS or any other Git source code provider like GitHub. 
 Review the [import repository documentation](../git/import-git-repository.md) for more details.
 
 ### Manually migrate the Git repo in 5 easy steps:

--- a/docs/collaborate/integration-bestpractices.md
+++ b/docs/collaborate/integration-bestpractices.md
@@ -76,4 +76,4 @@ Limit the number of links per work item as much as possible. We recommend that y
 ## Queries for Reporting
 Using queries and individual get work item calls is the number one way to get rate limits enforced on your account. Don't execute queries to return large lists of work items. Use the reporting [work item links](https://www.visualstudio.com/docs/integrate/api/wit/reporting-work-item-links) and [work item revisions](https://www.visualstudio.com/en-us/integrate/api/wit/reporting-work-item-revisions) REST API's instead.
 
-You can see our [C# Sample on Github](https://github.com/sferg-msft/vsts-wit-reporting-example)
+You can see our [C# Sample on GitHub](https://github.com/sferg-msft/vsts-wit-reporting-example)

--- a/docs/collaborate/markdown-guidance.md
+++ b/docs/collaborate/markdown-guidance.md
@@ -25,7 +25,7 @@ You can provide guidance to your team in these places using markdown:
 - [Pull request comments](../git/pull-requests.md) 
 - [Add Markdown to a dashboard](../report/add-markdown-to-dashboard.md)    
 
-In this topic you'll find some basic Markdown syntax guidance. You can use both common [Markdown conventions](http://daringfireball.net/projects/markdown/syntax) and [Github-flavored extensions](https://help.github.com/articles/github-flavored-markdown/).
+In this topic you'll find some basic Markdown syntax guidance. You can use both common [Markdown conventions](http://daringfireball.net/projects/markdown/syntax) and [GitHub-flavored extensions](https://help.github.com/articles/github-flavored-markdown/).
 
 ## Headers
 

--- a/docs/extend/_shared/procedures/create-web-page.md
+++ b/docs/extend/_shared/procedures/create-web-page.md
@@ -1,6 +1,6 @@
 1. Get the Client SDK `VSS.SDK.js` file and add it to your web app. Place it in the `home/sdk/scripts` folder.
 	1. Use the 'npm install' command to retrieve the SDK: `npm install vss-web-extension-sdk`. 
-	2. To learn more about the SDK, visit the [Client SDK Github Page](https://github.com/Microsoft/vss-sdk).
+	2. To learn more about the SDK, visit the [Client SDK GitHub Page](https://github.com/Microsoft/vss-sdk).
 
 1. Add the web page that you want to display as a hub. We're doing a simple `hello-world.html` page here, added to the `home` directory.
 

--- a/docs/extend/develop/add-chart.md
+++ b/docs/extend/develop/add-chart.md
@@ -53,7 +53,7 @@ To do so, in the `home` folder for your project, create a `chart.html` file with
 </body>
 </html>
 ```
-> Use the **npm install** command to retrieve the SDK: `npm install vss-web-extension-sdk`. To learn more about the SDK, visit the [Client SDK Github Page](https://github.com/Microsoft/vss-sdk).
+> Use the **npm install** command to retrieve the SDK: `npm install vss-web-extension-sdk`. To learn more about the SDK, visit the [Client SDK GitHub Page](https://github.com/Microsoft/vss-sdk).
 
 Ensure that the `VSS.SDK.js` file is inside the `sdk/scripts` folder so that the path is `home/sdk/scripts/VSS.SDK.js`.
 

--- a/docs/extend/develop/add-dashboard-widget.md
+++ b/docs/extend/develop/add-dashboard-widget.md
@@ -70,7 +70,7 @@ Use the 'npm install' command to retrieve the SDK:
 npm install vss-web-extension-sdk
 ```
 
->To learn more about the SDK, visit the [Client SDK Github Page](https://github.com/Microsoft/vss-sdk).
+>To learn more about the SDK, visit the [Client SDK GitHub Page](https://github.com/Microsoft/vss-sdk).
 
 ### Step 2: Your HTML page - `hello-world.html`
 This is the glue that holds your layout together and includes references to CSS and JavaScript. 

--- a/docs/extend/develop/add-hub.md
+++ b/docs/extend/develop/add-hub.md
@@ -39,7 +39,7 @@ Use the 'npm install' command via the command line (requires [Node](https://node
 npm install vss-web-extension-sdk
 ```
 
-> To learn more about the SDK, visit the [Client SDK Github Page](https://github.com/Microsoft/vss-sdk).
+> To learn more about the SDK, visit the [Client SDK GitHub Page](https://github.com/Microsoft/vss-sdk).
 
 ## Your hub page: `hello-world.html`
 * Every hub displays a web page

--- a/docs/extend/get-started/node.md
+++ b/docs/extend/get-started/node.md
@@ -65,7 +65,7 @@ Use the *npm install* command via the command line (requires [Node](https://node
 npm install vss-web-extension-sdk
 ```
 
-> To learn more about the SDK, visit the [Client SDK Github Page](https://github.com/Microsoft/vss-sdk).
+> To learn more about the SDK, visit the [Client SDK GitHub Page](https://github.com/Microsoft/vss-sdk).
 
 <a name="extension-manifest" />
 

--- a/docs/git/import-git-repository.md
+++ b/docs/git/import-git-repository.md
@@ -1,6 +1,6 @@
 ---
 title: Import a Git repo into your team project | VSTS & TFS
-description: Import a repo from Github, Gitlab, or BitBucket into your VSTS/TFS Team Project
+description: Import a repo from GitHub, GitLab, or Bitbucket into your VSTS/TFS Team Project
 ms.assetid: 5439629e-23fd-44f1-a345-f00a435f1430
 ms.prod: vs-devops-alm
 ms.technology: vs-devops-git 

--- a/docs/git/index.md
+++ b/docs/git/index.md
@@ -26,7 +26,7 @@ Get started by creating a repo, uploading your code, and inviting developers to 
 
 </div>
 
-Or, you can [import an existing repo](import-git-repository.md) from GitHub, BitBucket, GitLab, or other location to a new, empty repo. 
+Or, you can [import an existing repo](import-git-repository.md) from GitHub, Bitbucket, GitLab, or other location to a new, empty repo. 
 
 ## Step-by-Step Tutorials  
 

--- a/docs/tfs-server/whats-new.md
+++ b/docs/tfs-server/whats-new.md
@@ -276,7 +276,7 @@ For known issues, see [Known issues](https://www.visualstudio.com/news/releaseno
 
 ####[Git improvements](https://www.visualstudio.com/news/releasenotes/tfs2017-update1#vc)
 <ul>
-<li>Import a Git repository from GitHub, BitBucket, GitLab, or other locations</li>
+<li>Import a Git repository from GitHub, Bitbucket, GitLab, or other locations</li>
 <li>Add .gitignore during repo creation</li>
 <li>Restart pull request merge</li>
 <li>Markdown in pull request description</li>

--- a/release-notes/2014/may-12-team-services.md
+++ b/release-notes/2014/may-12-team-services.md
@@ -16,7 +16,7 @@ author: yukom
 
 Today we are releasing a preview of a new way to extend and integrate with Visual Studio Online using REST, OAuth, and service hooks. With this deployment you can:
 
--Integrate with many of the most popular cloud services; such as Trello, Campfire, Github, UserVoice, Zendesk and many more
+-Integrate with many of the most popular cloud services; such as Trello, Campfire, GitHub, UserVoice, Zendesk and many more
 -Develop custom apps and services that extend the power of Visual Studio Online
 
 You can find more information about the types of scenarios now possible at our [Visual Studio Online Integration](https://www.visualstudio.com/integrate/explore/explore-vso-vsi) hub.

--- a/release-notes/2016/jul-07-team-services.md
+++ b/release-notes/2016/jul-07-team-services.md
@@ -98,9 +98,9 @@ Write-host "##vso[task.uploadfile]<filename>"
 
 The file is then available as part of the release logs. When you download all the logs associated with the release, you will be able to retrieve this file as well.
 
-###Github artifacts for RM
+###GitHub artifacts for RM
 
-Continuing with the work we started last sprint on using Git and TFVC as artifact sources directly in RM, for this Sprint, we enabled the same for Github. If you need to deploy Node.js, JS, or PHP applications, where an explicit build step is not needed, and if you are using Github for managing your code, then you can now directly configure a Github artifact source in a release definition.
+Continuing with the work we started last sprint on using Git and TFVC as artifact sources directly in RM, for this Sprint, we enabled the same for GitHub. If you need to deploy Node.js, JS, or PHP applications, where an explicit build step is not needed, and if you are using GitHub for managing your code, then you can now directly configure a GitHub artifact source in a release definition.
 
 ###.NET SQL Extension
 

--- a/release-notes/2016/sep-21-team-services.md
+++ b/release-notes/2016/sep-21-team-services.md
@@ -38,7 +38,7 @@ To disable a work item type, go to the work item type’s **Overview** tab on th
 
 ##Import repository
 
-Customers can now import a Git repository from GitHub, BitBucket, GitLab, or other locations. You can import into either a new or an existing empty repository.
+Customers can now import a Git repository from GitHub, Bitbucket, GitLab, or other locations. You can import into either a new or an existing empty repository.
 
 ###Import into a new repository
 From the repository selector drop-down, click **Import repository**. 

--- a/release-notes/2017/feb-15-team-services.md
+++ b/release-notes/2017/feb-15-team-services.md
@@ -1,5 +1,5 @@
 ---
-title: PR usability improvements & richer Github build integration – Feb 15
+title: PR usability improvements & richer GitHub build integration – Feb 15
 description: VSTS release notes for Feb 15 2017
 ms.ContentId: 9b76c2f3-39ce-4c98-9cef-237853ee0349
 ms.prod: vs-devops-alm
@@ -8,7 +8,7 @@ ms.author: egeaney
 author: egeaney
 ---
 
-#PR usability improvements & richer Github build integration – Feb 15
+#PR usability improvements & richer GitHub build integration – Feb 15
 
 **Note:** The improvements discussed in this post are features that will be rolling out over the next three weeks.
 

--- a/release-notes/2017/mar-08-team-services.md
+++ b/release-notes/2017/mar-08-team-services.md
@@ -54,7 +54,7 @@ Ensure that all comments in your pull requests are being addressed with the new 
 ##Build agent upgrade status
 When an agent is being upgraded, it now indicates the status of the upgrade in the queue and pool management portal.
 
-##Github pull request builds
+##GitHub pull request builds
 For a while, we’ve provided CI builds from your GitHub repo. Now we’re adding a new trigger so you can build your GitHub pull requests automatically. After the build is done, we report back with a comment in your GitHub pull request.
 
 For security, we only build pull requests when both the source and target are within the same repo. We don’t build pull requests from a forked repo.

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -1016,7 +1016,7 @@ Versions in the “Server” column are linked to the appropriate download locat
             <td style="background:rgb(155, 192, 230);">2017.2</td>
         </tr>
         <tr>
-            <td>Github pull request builds</td>
+            <td>GitHub pull request builds</td>
             <td style="background:rgb(232, 232, 232);">Future</td>
         </tr>
         <tr>
@@ -1736,7 +1736,7 @@ Versions in the “Server” column are linked to the appropriate download locat
             <td style="background:rgb(240, 245, 251);">[2017](http://go.microsoft.com/fwlink/?LinkId=831912)</td>
         </tr>
         <tr>
-            <td>Github artifacts for RM</td>
+            <td>GitHub artifacts for RM</td>
             <td style="background:rgb(240, 245, 251);">[2017](http://go.microsoft.com/fwlink/?LinkId=831912)</td>
         </tr>
         <tr>


### PR DESCRIPTION
Use the correct capitalization when referring to our friends in the Git hosting community: GitHub, GitLab and Bitbucket.
