### PR TITLE
Update ci-build-git.md

### DIFF
--- a/docs/build-release/actions/ci-build-git.md
+++ b/docs/build-release/actions/ci-build-git.md
@@ -42,7 +42,7 @@ A common workflow with Git is to create temporary branches from your master bran
 2. Locate the **Build Definition** that services your master branch.  Click the **ellipsis** to the right of your definition.  Click **Edit**.
 3. Click the **Triggers** menu for your build.  Ensure you have **Continuous Integration** enabled.
 4.  Click the **+ Add** icon under **Branch Filters**.
-5.  Type **features/*** in the **Branch specification** dropdown.  The trigger supports CI for feature branches that match the wildcard as well as the master branch.    
+5.  Under the **Branch specification** dropdown, type **features/*** in the "Filter my Branches" text box then hit **ENTER**.  The trigger now supports CI for all feature branches that match the wildcard as well as the master branch.
     ![Code hub in VSTS portal](_img/ci-build-git/triggerwildcard.png)
 6.  Click the **Save & queue** menu and then click **Save**.
 


### PR DESCRIPTION
Updated verbiage around setting up a CI trigger for a topic branch, as the original wording was vague and misleading (made it sound like you could type in the dropdown box directly).