### PR TITLE
Update administration.md to fix path to TFS in Unconfigure Code Search

### DIFF
--- a/docs/search/code/administration.md
+++ b/docs/search/code/administration.md
@@ -538,9 +538,9 @@ install. This requires multiple steps, depending on whether Code Search is confi
    1. Open **Command Prompt** as an administrator
    1. Change directory: 
 
-      For TFS 2017 RTM, `cd "C:\Program Files\TFS 15.0\Search\ES\elasticsearch-1.7.1-SNAPSHOT\bin"`
+      For TFS 2017 RTM, `cd "C:\Program Files\Microsoft Team Foundation Server 15.0\Search\ES\elasticsearch-1.7.1-SNAPSHOT\bin"`
 
-      For TFS 2017 Update1 and above, `cd "C:\Program Files\TFS 15.0\Search\ES\elasticsearch-2.4.1\bin"`
+      For TFS 2017 Update1 and above, `cd "C:\Program Files\Microsoft Team Foundation Server 15.0\Search\ES\elasticsearch-2.4.1\bin"`
       
    1. Remove the service: `"service.bat remove"`<p />
     


### PR DESCRIPTION
Replace "TFS 15.0" with "Microsoft Team Foundation Server 15.0" in path to ElasticSearch located in this section: https://docs.microsoft.com/en-us/vsts/search/code/administration#unconfigure-search-in-team-foundation-server