### PR TITLE
Supported version to TFS 2018

### DIFF
--- a/docs/integrate/get-started/rest/basics.md
+++ b/docs/integrate/get-started/rest/basics.md
@@ -267,6 +267,7 @@ GET https://{account}.visualstudio.com/defaultcollection/_apis/{area}/{resource}
 | Product                     | 1.0    | 2.0    | 3.0    |
 |:----------------------------|:------:|:------:|:------:|
 | VSTS               | X      | X      | X      | 
+| Team Foundation Server 2018 | X      | X      | X      |
 | Team Foundation Server 2017 | X      | X      | X      |
 | Team Foundation Server 2015 | X      | X      | -      |
 

--- a/docs/integrate/get-started/rest/basics.md
+++ b/docs/integrate/get-started/rest/basics.md
@@ -264,14 +264,14 @@ GET https://{account}.visualstudio.com/defaultcollection/_apis/{area}/{resource}
 
 ### Supported versions
 
-| Product                     | 1.0    | 2.0    | 3.0    |
-|:----------------------------|:------:|:------:|:------:|
-| VSTS               | X      | X      | X      | 
-| Team Foundation Server 2018 | X      | X      | X      |
-| Team Foundation Server 2017 | X      | X      | X      |
-| Team Foundation Server 2015 | X      | X      | -      |
+| Product                     | 1.0    | 2.0    | 3.0    | 4.0    |
+|:----------------------------|:------:|:------:|:------:|:------:|
+| VSTS               	      | X      | X      | X      | X      | 
+| Team Foundation Server 2018 | X      | X      | X      | X      |
+| Team Foundation Server 2017 | X      | X      | X      | -      |
+| Team Foundation Server 2015 | X      | X      | -      | -      |
 
-Major API version releases align with Team Foundation Server RTM releases. For example, the `3.0` API set was introduced with Team Foundation Server 2017.
+Major API version releases align with Team Foundation Server RTM releases. For example, the `4.0` API set was introduced with Team Foundation Server 2018.
 
 A small number of undocumented version 1.0 APIs existed in Team Foundation Server 2013, but are not supported.
 


### PR DESCRIPTION
Including supported version to Team Foundation Server 2018 on ### Supported versions section