### PR TITLE
Correct the example for quotes

### DIFF
--- a/docs/collaborate/markdown-guidance.md
+++ b/docs/collaborate/markdown-guidance.md
@@ -91,8 +91,8 @@ Quote blocks of lines of text by using the same level of `>` across multiple lin
 <pre>
 > Single line quote
 >> Nested quote   
-> multiple line
-> quote
+>> multiple line
+>> quote
 </pre>
 
 **Result:**  


### PR DESCRIPTION
The image for the quote example is not produced from the input. Fixed the input to match output.