### PR TITLE
Update "Discussion section" tip

### DIFF
--- a/docs/work/work-items/guidance/scrum-process-workflow.md
+++ b/docs/work/work-items/guidance/scrum-process-workflow.md
@@ -71,7 +71,7 @@ Use the following guidance and that provided for [fields used in common across w
 
 
 > [!TIP]    
-> Use the [Discussion section](../../work-items/work-item-form-controls.md#discussion) to add and review comments made about the work being performed. This feature is only available from VSTS.  
+> Use the [Discussion section](../../work-items/work-item-form-controls.md#discussion) to add and review comments made about the work being performed.  
 
 ## Track progress
 


### PR DESCRIPTION
Removing "This feature is only available from VSTS." The "Discussion" features is available on "VSTS | TFS 2018 | TFS 2017" as per https://docs.microsoft.com/en-us/vsts/work/work-items/work-item-form-controls#discussion