### PR TITLE
Update list of supported TFS versions

### DIFF
--- a/docs/build-release/apps/cd/azure/deploy-azure-scaleset.md
+++ b/docs/build-release/apps/cd/azure/deploy-azure-scaleset.md
@@ -11,7 +11,7 @@ ms.date: 09/26/2017
 
 # Implement continuous deployment of your app to an Azure Virtual Machine Scale Set
 
-[!INCLUDE [version-rm-dev14](../../../_shared/version-rm-dev14.md)]
+VSTS | TFS 2018 | TFS 2017
 
 The **Build Machine Image** task makes it easy for users who are new to immutable
 VHD-based deployments to use **Packer** without learning concepts such as provisioners


### PR DESCRIPTION
Removing TFS 2015 from supported versions, "build Machine Image" is only available starting TFS 2017