### PR TITLE
Add missing url to list of whitelist urls

### DIFF
--- a/docs/build-release/actions/agents/_shared/v2/qa-firewall.md
+++ b/docs/build-release/actions/agents/_shared/v2/qa-firewall.md
@@ -8,4 +8,5 @@ https://app.vssps.visualstudio.com
 https://{accountname}.visualstudio.com
 https://{accountname}.vsrm.visualstudio.com
 https://{accountname}.pkgs.visualstudio.com
+https://{accountname}.vssps.visualstudio.com
  ```


### PR DESCRIPTION
Noticed {accountname}.vssps.visualstudio.com also is required