### PR TITLE
Typo in docs/security/export-users-audit-log.md

### DIFF
--- a/docs/security/export-users-audit-log.md
+++ b/docs/security/export-users-audit-log.md
@@ -29,7 +29,7 @@ You can get a list of users and groups that have access to your Visual Studio Te
 
 	<img src="_img/export-users-audit/go-to-users-hub.png" alt="From the Users hub, click Export users" style="border: 1px solid #C3C3C3;" />  
 
-	Otherwise, the the URL follows this pattern: ```https://{account name}.visualstudio.com/_users```  
+	Otherwise, the URL follows this pattern: ```https://{account name}.visualstudio.com/_users```  
 
 	<img src="_img/export-users-audit/go-to-users-hub-not-streamlined.png" alt="From the Users hub, click Export users" style="border: 1px solid #C3C3C3;" />  
 


### PR DESCRIPTION
Remove duplicated 'the'.