### PR TITLE
Typo in example-queries.md

### DIFF
--- a/docs/work/track/example-queries.md
+++ b/docs/work/track/example-queries.md
@@ -15,7 +15,7 @@ ms.date: 09/29/2017
 
 [!INCLUDE [temp](../_shared/version-vsts-tfs-all-versions.md)]
 
-A query lists a filtered set of work items. You can initiate a query using the the [query editor](using-queries.md). Optionally, you can perform an adhoc search using the [search box](search-box-queries.md). 
+A query lists a filtered set of work items. You can initiate a query using the [query editor](using-queries.md). Optionally, you can perform an adhoc search using the [search box](search-box-queries.md). 
 
 With queries, you can perform these functions: 
 


### PR DESCRIPTION
Remove duplicated 'the'.