### PR TITLE
add note for not supported task group feature

### DIFF
--- a/docs/build-release/actions/build-yaml.md
+++ b/docs/build-release/actions/build-yaml.md
@@ -125,6 +125,9 @@ To look up the syntax of the tasks that are built into VSTS and TFS, see https:/
 
 For example, if you want to use the [Copy Files](../tasks/utility/copy-files.md) task, go to https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/CopyFiles and then click the **task.json** file. In this file you'll find the name of task, which in this case is `CopyFiles`. You'll also find the valid `inputs`, for example the `SourceFolder` input.
 
+> [!NOTE]
+> [Task Groups](https://docs.microsoft.com/en-us/vsts/build-release/concepts/library/task-groups) are not supported yet.
+
 ## Learn more
 
 To learn more about what you can do with YAML builds, see https://github.com/Microsoft/vsts-agent/blob/master/docs/preview/yamlgettingstarted.md.


### PR DESCRIPTION
Right now there is not hint that Task Groups are not supported right now. Just the YAML views shows, that Task Groups are not supprted yet.
![image](https://user-images.githubusercontent.com/6189336/37354705-8bf93e26-26e2-11e8-8db7-9ba7d2785760.png)
