### PR TITLE
fix code block identifier

### DIFF
--- a/docs/integrate/quickstarts/create-bug-quickstart.md
+++ b/docs/integrate/quickstarts/create-bug-quickstart.md
@@ -10,7 +10,6 @@ ms.date: 06/27/2017
 ms.custom: get-started-article
 ms.topic: get-started-article
 ---
-
 # Create a bug in Visual Studio Team Services using .NET client libraries
 
 Creating a new bug (or any work item) is pretty straight forward. You just need to set the field values and send a JSON-Patch object to the REST endpoint.
@@ -39,7 +38,7 @@ There are a few things happening in the code sample below:
     0. Send that serialized json object to the REST endpoint
 
 ## C# code snippet
-```c#
+```csharp
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -142,7 +141,7 @@ public class CreateBug
 }
 ```
 
-## Next Steps
+## Next steps
 
 * Check out another Quickstart: [Get a list of work items using queries](./work-item-quickstart.md)
 * Explore the [integrate samples](../get-started/client-libraries/samples.md)


### PR DESCRIPTION
The topic https://docs.microsoft.com/en-us/vsts/integrate/quickstarts/create-bug-quickstart didn't have the right colorization because it's using the wrong identifier for the C# snippet. 

I also fixed the heading to be sentence case as Microsoft style guide suggests (https://docs.microsoft.com/en-us/style-guide/scannable-content/headings#formatting-headings).