### PR TITLE
chore(team field): Fix code fences and headings

### DIFF
--- a/docs/work/customize/use-team-fields-instead-area-paths.md
+++ b/docs/work/customize/use-team-fields-instead-area-paths.md
@@ -12,8 +12,7 @@ ms.date: 04/14/2017
 
 # Use team fields instead of area paths to support teams
 
-[!IN
-CLUDE [temp](../_shared/version-header-tfs-only.md)]
+[!INCLUDE [temp](../_shared/version-header-tfs-only.md)]
 
 > [!IMPORTANT]  
 >**Feature availability:**&#160;&#160;Team fields are only supported for on-premises TFS. Team fields are not supported in VSTS. 
@@ -51,19 +50,19 @@ When you customize your team project to support team fields, the Team field tab 
 
     Add the global list definition for your team. Include a value you'll want to use for items not yet assigned to a team. If your global list is empty, simply copy the following code, paste into the XML file, and modify to support your team labels.
 
-        > [!div class="tabbedCodeSnippets"]
-		```XML
-		<?xml version="1.0" encoding="utf-8"?>
-        <gl:GLOBALLISTS xmlns:gl="http://schemas.microsoft.com/VisualStudio/2005/workitemtracking/globallists">
-        &nbsp;&nbsp;&nbsp;<GLOBALLIST name="Teams">
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<LISTITEM value="Unassigned"/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<LISTITEM value="Team A"/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<LISTITEM value="Team B"/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<LISTITEM value="Team C"/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<LISTITEM value="Team D"/>
-        &nbsp;&nbsp;&nbsp;</GLOBALLIST>
-        </gl:GLOBALLISTS>
-		```
+
+```XML
+<?xml version="1.0" encoding="utf-8"?>
+<gl:GLOBALLISTS xmlns:gl="http://schemas.microsoft.com/VisualStudio/2005/workitemtracking/globallists">
+   <GLOBALLIST name="Teams">
+    <LISTITEM value="Unassigned"/>
+    <LISTITEM value="Team A"/>
+    <LISTITEM value="Team B"/>
+    <LISTITEM value="Team C"/>
+    <LISTITEM value="Team D"/>
+   </GLOBALLIST>
+</gl:GLOBALLISTS>
+```
 
 0.  Import the global list definition.
 
@@ -87,42 +86,40 @@ Add a custom team field to all work item types (WITs) that are included in the F
 
 2.  For each type, add a custom Team field that references the global list.
 
-        > [!div class="tabbedCodeSnippets"]
-		```XML
-        <FIELDS>
-        . . . 
-        &nbsp;&nbsp;&nbsp;<FIELD name="Team" refname="MyCompany.Team" type="String" reportable="dimension">
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<HELPTEXT>Name of the team that will do the work.</HELPTEXT>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<ALLOWEXISTINGVALUE />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<ALLOWEDVALUES >
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<GLOBALLIST name="Teams" />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</ALLOWEDVALUES >
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<DEFAULT from="value" value="Unassigned" />
-        &nbsp;&nbsp;&nbsp;</FIELD>
-        . . . 
-        </FIELDS>
-		```
+```XML
+  <FIELDS>
+  . . . 
+     <FIELD name="Team" refname="MyCompany.Team" type="String" reportable="dimension">
+      <HELPTEXT>Name of the team that will do the work.</HELPTEXT>
+      <ALLOWEXISTINGVALUE />
+       <ALLOWEDVALUES >
+        <GLOBALLIST name="Teams" />
+       </ALLOWEDVALUES >
+       <DEFAULT from="value" value="Unassigned" />
+     </FIELD>
+  . . . 
+  </FIELDS>
+```
 
     > [!TIP]  
     >Name your custom field to distinguish it from other system fields. Do not use "System" as a prefix for `refname`. And, keep the `name` and `refname` labels to 128 characters and 70, respectively.
 
 3.  Add the **Team** field to the [Layout section](reference/layout-xml-element-reference.md) of the work item form. If you are working in VSTS and TFS 2017, you'll also need to edit the [**WebLayout** section](reference/weblayout-xml-elements.md) of the WIT definition. 
 
-        > [!div class="tabbedCodeSnippets"]
-		```XML
-        <FORM>
-        . . . 
-        &nbsp;&nbsp;&nbsp;<Group Label="Status">
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<Column PercentWidth="100">
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<Control FieldName="MyCompany.Team" Type="FieldControl" Label="Team" LabelPosition="Left" EmptyText="&lt;None&gt;" />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<Control Type="FieldControl" FieldName="System.AssignedTo" Label="Assi&amp;gned to:" LabelPosition="Left" />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<Control FieldName="System.State" Type="FieldControl" Label="Stat&amp;e" LabelPosition="Left" />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<Control FieldName="System.Reason" Type="FieldControl" Label="Reason" LabelPosition="Left" ReadOnly="True" />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</Column>
-        &nbsp;&nbsp;&nbsp;</Group>
-        . . . 
-        </FORM>
-		```
+```XML
+  <FORM>
+  . . . 
+     <Group Label="Status">
+      <Column PercentWidth="100">
+       <Control FieldName="MyCompany.Team" Type="FieldControl" Label="Team" LabelPosition="Left" EmptyText="&lt;None&gt;" />
+       <Control Type="FieldControl" FieldName="System.AssignedTo" Label="Assi&amp;gned to:" LabelPosition="Left" />
+       <Control FieldName="System.State" Type="FieldControl" Label="Stat&amp;e" LabelPosition="Left" />
+       <Control FieldName="System.Reason" Type="FieldControl" Label="Reason" LabelPosition="Left" ReadOnly="True" />
+       </Column>
+     </Group>
+  . . . 
+  </FORM>
+```
 
     Optionally, move the Area Path field to appear before or after the Iteration Path.
 
@@ -146,17 +143,17 @@ Add a custom team field to all work item types (WITs) that are included in the F
 
 3.  (Optional) Add the Team field to the quick add panel for the backlog page.  
   
-        > [!div class="tabbedCodeSnippets"]
-		```XML
-        <RequirementBacklog category="Microsoft.RequirementCategory" parent="Microsoft.FeatureCategory" pluralName="Stories" singularName="User Story">
-            <AddPanel>
-              <Fields>
-                <Field refname="System.Title" />
-                <Field refname="MyCompany.Team " />
-              </Fields>
-            </AddPanel> 
-        . . .
-		```
+
+```XML
+  <RequirementBacklog category="Microsoft.RequirementCategory" parent="Microsoft.FeatureCategory" pluralName="Stories" singularName="User Story">
+    <AddPanel>
+      <Fields>
+      <Field refname="System.Title" />
+      <Field refname="MyCompany.Team " />
+      </Fields>
+    </AddPanel> 
+  . . .
+```
 
 4.  Import the definition file.
 
@@ -225,17 +222,19 @@ For backlog items you create from a team's backlog page, TFS assigns the default
 
 2.  [Download the process template](../work-items/guidance/manage-process-templates.md) that corresponds to the template used to create your team project.
 
-	> [!IMPORTANT]  
-	>Make sure that you download the process template from the upgraded server. Also, the Visual Studio client version you use for both the download process and using **witadmin** must match the server version. For example, if you have upgraded to TFS 2015, you need to work from Visual Studio 2015. If you use an older version of Visuals Studio, you may get errors during the upload process. 
+  > [!IMPORTANT]  
+  >Make sure that you download the process template from the upgraded server. Also, the Visual Studio client version you use for both the download process and using **witadmin** must match the server version. For example, if you have upgraded to TFS 2015, you need to work from Visual Studio 2015. If you use an older version of Visuals Studio, you may get errors during the upload process. 
 
 3.  Modify the ProcessTemplate file, and update the process template name and version number. For example:
 
-        <?xml version="1.0" encoding="utf-8"?>
-        <ProcessTemplate>
-          <metadata>
-            <name>Microsoft Visual Studio Scrum 2013.3 with Team Field</name>
-            <description>This template is for teams who follow the Scrum methodology and use Scrum terminology.</description>
-            <version type="6B724908-EF14-45CF-84F8-768B5384DA45" major="3" minor="60" />
+```XML
+<?xml version="1.0" encoding="utf-8"?>
+<ProcessTemplate>
+  <metadata>
+    <name>Microsoft Visual Studio Scrum 2013.3 with Team Field</name>
+    <description>This template is for teams who follow the Scrum methodology and use Scrum terminology.</description>
+    <version type="6B724908-EF14-45CF-84F8-768B5384DA45" major="3" minor="60" />
+```
 
 4.  As described earlier in this topic, [Add a custom team field to work item types](#addteamfield), update the WIT definitions for the work item types assigned to the Feature, Requirements, and Task categories. For the Scrum process template, this corresponds to the Feature, Product Backlog Item, Bug, Task, and Test Plan WITs.
 
@@ -248,6 +247,6 @@ For backlog items you create from a team's backlog page, TFS assigns the default
 
 
 
-###Credits
+### Credits
 
 Guidance for [customizing teams decoupled from area paths](http://blog.hinshelwood.com/team-foundation-server-2012-teams-without-areas/) was developed in partnership with [Martin Hinshel](http://blog.hinshelwood.com), a senior devops consultant and Microsoft Visual Studio ALM MVP.


### PR DESCRIPTION
The code fences had blockquotes inserted before them and didn't render.
Converted them back and pinned them to the left gutter.
The final Credit header had a stuck heading which doesn't render on GH anymore