### PR TITLE
Update wrong "Path to publish"

### DIFF
--- a/docs/build-release/concepts/definitions/build/artifacts.md
+++ b/docs/build-release/concepts/definitions/build/artifacts.md
@@ -91,7 +91,7 @@ The completed build delivers two sets of artifacts.
 * Source folder
 
  ```
-$(Build.ArtifactStagingDirectory)
+$(Build.SourcesDirectory)
 ```
 
 * Contents


### PR DESCRIPTION
I think that the `Source folder` should be `$(Build.SourcesDirectory)` instead of `$(Build.ArtifactStagingDirectory)`. Otherwise, you're copying files from the same place you're dropping them.

This is for the "C++ app" section in the "Artifacts in Team Build"