### PR TITLE
Fix "Add New Item" instructions

### DIFF
--- a/docs/integrate/ide/extensions/hello_world.md
+++ b/docs/integrate/ide/extensions/hello_world.md
@@ -37,7 +37,7 @@ If you need to leave this tutorial and come back to it, you can find your new He
 ## Add a Custom command
 
 1.	If you select the manifest, you can see what options are changeable, for instance, metadata, description, and version.
-2.	Right-click the project (not the solution). On the context menu, click **Add**, and then click **User Control**.
+2.	Right-click the project (not the solution). On the context menu, click **Add**, and then click **New Item**.
 3.	Go back to the **Extensibility** section, and then click **Custom Command**.
   ![Image of the Custom Command window](./_img/custom-command.png)
 4.  In the **Name** field at the bottom, give it a name, for instance Command.cs.


### PR DESCRIPTION
Having the user attempt to add a User Control as a way of opening the "Add New Item" dialog is confusing.  Especially when the "User Control" item they need to click is right next to the "New Item" item anyway,