### PR TITLE
fix: upstream-sources link from absolute to rel

### DIFF
--- a/docs/package/get-started-npm.md
+++ b/docs/package/get-started-npm.md
@@ -184,7 +184,7 @@ When using a task runner, you'll need to add the **npm Authenticate** build task
 
 ## Step 4: Use packages from npmjs.com
 
-In addition to packages you publish, you can use packages from [www.npmjs.com](https://www.npmjs.com/) through this feed via *upstream sources*. Because this feed was created with public registries enabled (see [Step 2](#step-2-create-a-feed)), you should be able to use packages from an upstream source. To try it out, just run an `npm install` command (e.g. `npm install lodash`) in a shell opened to your project's folder. Learn more about upstream sources on the [upstream sources concepts page](/concepts/upstream-sources.md).
+In addition to packages you publish, you can use packages from [www.npmjs.com](https://www.npmjs.com/) through this feed via *upstream sources*. Because this feed was created with public registries enabled (see [Step 2](#step-2-create-a-feed)), you should be able to use packages from an upstream source. To try it out, just run an `npm install` command (e.g. `npm install lodash`) in a shell opened to your project's folder. Learn more about upstream sources on the [upstream sources concepts page](concepts/upstream-sources.md).
 
 You can choose to enable or disable upstream sources in the _Settings_ -> _Upstream sources_ tab:
 


### PR DESCRIPTION
Was resolving to 
https://docs.microsoft.com/en-us/concepts/upstream-sources.md 
instead of
https://docs.microsoft.com/en-us/vsts/package/concepts/upstream-sources