### PR TITLE
Update instructions on how to enable "Allow scripts to access the OAuth token

### DIFF
--- a/docs/build-release/actions/scripts/git-commands.md
+++ b/docs/build-release/actions/scripts/git-commands.md
@@ -69,7 +69,11 @@ On the [variables tab](../../concepts/definitions/build/variables.md) set this v
 |---|---|
 | ```system.prefergit``` | ```true``` |
 
-On the [options tab](../../concepts/definitions/build/options.md) select **Allow scripts to access OAuth token**.
+### Enable scripts to access OAuth token
+- Select "Tasks" tab in the build definition
+- Select the agent phase containing the tasks/scripts which will use git
+- Expand the "Additional Options" section
+- Enable the **Allow scripts to access OAuth token** option
 
 ## Make sure to clean up the local repo
 


### PR DESCRIPTION
It seems the "Allow scripts to access the OAuth token" option used to be a global option for the build definition and now it is an option scoped to the Agent Phase task group.

I imagine there are many other places where the docs need to be updated such as referenced below but someone with more familiarity with docs can do that.

Example of other reference to "Allow scripts to access the OAuth token"
https://docs.microsoft.com/en-us/vsts/build-release/concepts/definitions/build/options?view=vsts#allow-scripts-to-access-the-oauth-token
The "Allow scripts to access the OAuth token" is no longer on the "Options" tab so I think it could be removed from here, but it's not clear if this is correct change to make as it is technically still an option just not a global option.