### PR TITLE
Incorrect spacing in script entry

### DIFF
--- a/docs/package/npm/npmrc.md
+++ b/docs/package/npm/npmrc.md
@@ -46,7 +46,7 @@ If you are developing on Windows, we recommend that you use `vsts-npm-auth` to f
 
 ```json
 "scripts": {
-    "refreshVSToken ": "vsts-npm-auth -config .npmrc"
+    "refreshVSToken" : "vsts-npm-auth -config .npmrc"
 }
 ```
 


### PR DESCRIPTION
When copying the code like that running npm start refreshVSToken does not work.