### PR TITLE
Rename taskIcon.png to icon.png

### DIFF
--- a/docs/extend/develop/build-task-schema.md
+++ b/docs/extend/develop/build-task-schema.md
@@ -41,20 +41,20 @@ multiple versions in one extension.
 * Task1
     * Task1V1
         * task.json
-        * taskIcon.png
+        * icon.png
         * taskScript.ps1
     * Task1V2
         * task.json
-        * taskIcon.png
+        * icon.png
         * taskScript.ps1    
 * Task2
     * Task2V1
         * task.json
-        * taskIcon.png
+        * icon.png
         * taskScript.ps1
     * Task2V2
         * task.json
-        * taskIcon.png
+        * icon.png
         * taskScript.ps1
                     
 


### PR DESCRIPTION
The icon does not get picked up when naming it as taskIcon.png. Renaming it to limit confusion.