### PR TITLE
Correcting a copy and paste error.

### DIFF
--- a/docs/work/scrum/index.md
+++ b/docs/work/scrum/index.md
@@ -62,6 +62,6 @@ Whether you use scrum, Kanban, or a combination of Agile methods, you can get st
 - [Kanban](../kanban/index.md)
 - [Work item queries](../track/index.md)
 - [Work item customization](../customize/index.md)
-- [What is Scrum?](/azure/devops/agile/what-is-agile-development)
+- [What is Scrum?](/azure/devops/agile/what-is-scrum)
 - [What is Agile development?](/azure/devops/agile/what-is-agile-development)  
 


### PR DESCRIPTION
Correcting a copy and paste error. Both What is Scrum and What is Agile Development point to what is agile development. Clearly the What is scrum should point to what is scrum doc.