### PR TITLE
fix: Add redirect for VSTS support link

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -4960,6 +4960,11 @@
         "source_path": "docs/billing/extensions.md",
         "redirect_url": "/vsts/marketplace/overview",
         "redirect_document_id": false
+       },
+       {
+        "source_path": "https://www.visualstudio.com/team-services/support-visual-studio-team-services",
+        "redirect_url": "https://www.visualstudio.com/team-services/support/",
+        "redirect_document_id": false
        }
     ]
 }


### PR DESCRIPTION
Not sure this is correct. The old link is dead, and I found the new one through the Support menu on the portal.