### PR TITLE
fix: Add redirect for Dev Essentials

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -4960,6 +4960,11 @@
         "source_path": "docs/billing/extensions.md",
         "redirect_url": "/vsts/marketplace/overview",
         "redirect_document_id": false
+       },
+       {
+        "source_path": "https://www.visualstudio.com/products/visual-studio-dev-essentials-vs.aspx",
+        "redirect_url": "https://www.visualstudio.com/dev-essentials/",
+        "redirect_document_id": false
        }
     ]
 }


### PR DESCRIPTION
Old link is 404, found new through the menu