### PR TITLE
Update link for Code Search

### DIFF
--- a/docs/tfs-server/requirements.md
+++ b/docs/tfs-server/requirements.md
@@ -431,7 +431,7 @@ agents on your TFS application tiers.
 
 If you plan to use Code Search, we typically recommend setting up a separate server for it. 
 For more details, see 
-[hardware requirements for Code Search](../search/code/administration.md#hardware-recommendations).
+[hardware requirements for Code Search](../search/code/administration?view=tfs-2017).
 
 If you plan to use reporting features, we recommend setting up a separate 
 server for your warehouse database and Analysis Services cube or using a 


### PR DESCRIPTION
Update the h/w requirements link for Code Search to point to the TFS 2017 documentation of Code Search rather than the VSTS version.