### PR TITLE
Fix links in Extend folder

### DIFF
--- a/docs/extend/develop/add-build-task.md
+++ b/docs/extend/develop/add-build-task.md
@@ -146,7 +146,7 @@ Here is a description of some of the components of the `task.json` file.
 >[!NOTE]
 >For a more in-depth look into the task.json file, or to learn how to bundle multiple versions in your extension, check out the **[build/release task reference](./build-task-schema.md)**
 
-You can explore the **[vso-agent-tasks](https://github.com/Microsoft/vso-agent-tasks/tree/master/Tasks)** repository on GitHub for multiple examples ([Grunt](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Grunt) is a good one).        
+You can explore the **[vso-agent-tasks](https://github.com/Microsoft/vso-agent-tasks/tree/master/Tasks)** repository on GitHub for multiple examples ([Grunt](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/GruntV0) is a good one).        
 
 <a name="extensionmanifest" />
 ## Step 2: Create the extension manifest file

--- a/docs/extend/develop/add-chart.md
+++ b/docs/extend/develop/add-chart.md
@@ -31,7 +31,7 @@ The following chart types are supported:
 0. Pivot table
 0. Histogram 
 
-> If you're in a hurry and want to get your hands on the code right away, you can download the [complete samples] (https://github.com/Microsoft/vsts-extension-samples).
+> If you're in a hurry and want to get your hands on the code right away, you can download the [complete samples](https://github.com/Microsoft/vsts-extension-samples).
 Once downloaded, go to the `charts` folder, then follow [the packaging and publishing instructions](../publish/overview.md) to publish the sample extension.
 The extension contains sample chart widgets.  
 


### PR DESCRIPTION
- space in markdown link
- The Grunt task folder in vso-agent-tasks was renamed to `GruntV0`