### PR TITLE
fix: SqlAzureDacpacDeployment renamed to V1

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -2943,7 +2943,7 @@
         },
         {
             "source_path": "docs/build-release/tasks/deploy/azure-sql-database-deployment.md",
-            "redirect_url": "https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/SqlAzureDacpacDeployment",
+            "redirect_url": "https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/SqlAzureDacpacDeploymentV1",
             "redirect_document_id": false
         },
         {

--- a/docs/build-release/apps/cd/sql-server-actions.md
+++ b/docs/build-release/apps/cd/sql-server-actions.md
@@ -16,7 +16,7 @@ monikerRange: '>= tfs-2015'
 
 [!INCLUDE [temp](../../_shared/version-rm-dev14.md)]
 
-VSTS and TFS include a SQL task named [SQL Azure Dacpac Deployment](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/SqlAzureDacpacDeployment)
+VSTS and TFS include a SQL task named [SQL Azure Dacpac Deployment](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/SqlAzureDacpacDeploymentV1)
 that helps you publish to SQL server.
 However, you may want to perform other SQL server actions
 as part of your release workflow.


### PR DESCRIPTION
Task folder in repo has renamed. There is a redirect to this file I'll fix in a separate commit