### PR TITLE
fix: absolute to relative link for link

### DIFF
--- a/docs/service-hooks/services/flowdock.md
+++ b/docs/service-hooks/services/flowdock.md
@@ -80,7 +80,7 @@ for pricing related to their services.
 
 ####Q: Can I programmatically create subscriptions?
 
-A: Yes, see details [here](http://www.visualstudio.com/integrate/get-started/service-hooks/create-subscription.md).
+A: Yes, see details [here](..//create-subscription.md).
 
 ####Q: Where can I get more information about Flowdock?
 


### PR DESCRIPTION
Previous liking didn't work because of the absolute link with the `.md` extension in the link. Alternate fix is just to drop that and keep the absolute link