### PR TITLE
fix: Correct 2017 Agent version information

### DIFF
--- a/docs/pipelines/agents/v2-windows.md
+++ b/docs/pipelines/agents/v2-windows.md
@@ -146,7 +146,9 @@ The help provides information on authentication alternatives and unattended conf
 | TFS version | Agent version |
 |-|-|
 | 2017 RTM | 2.105.7 |
-| 2017.3 | 2.112.0 |
+| 2017.1 | 2.112.0 |
+| 2017.2 | 2.117.2 |
+| 2017.3 | 2.122.1 |
 
 ::: moniker-end
 


### PR DESCRIPTION
Closes #924

In the tag/release descriptions:
https://github.com/Microsoft/vsts-agent/releases/tag/v2.112.0
https://github.com/Microsoft/vsts-agent/releases/tag/v2.117.2
https://github.com/Microsoft/vsts-agent/releases/tag/v2.122.1
I'm going to ask them to update the description on the last tag, but that is the version from my own 2017.3.1 server. The 2017 Update 3.1 was a security/app tier only update so I didn't list it.