### PR TITLE
fix: VsTest folder renamed to V2 on GH

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -3622,7 +3622,7 @@
     },
     {
       "source_path": "docs/build-release/tasks/test/visual-studio-test.md",
-      "redirect_url": "https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md",
+      "redirect_url": "https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md",
       "redirect_document_id": false
     },
     {

--- a/docs/pipelines/tasks/test/publish-test-results.md
+++ b/docs/pipelines/tasks/test/publish-test-results.md
@@ -26,7 +26,7 @@ including [JUnit](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xs
 Visual Studio Test (TRX), and
 [xUnit 2](https://xunit.github.io/docs/format-xml-v2.html). 
 If you use the built-in tasks such as
-[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)
+[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)
 to run tests, results are automatically published and you do not need a separate publish test results task.  
 
 ## Demands
@@ -62,7 +62,7 @@ The build agent must have the following capabilities:
 
 ## Related tasks
 
-* [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)  
+* [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)  
 * [Publish Code Coverage Results](publish-code-coverage-results.md)
 
 ## Q&A

--- a/docs/pipelines/tasks/test/run-functional-tests.md
+++ b/docs/pipelines/tasks/test/run-functional-tests.md
@@ -17,7 +17,7 @@ monikerRange: '>= tfs-2015'
 ::: moniker range=">= tfs-2018"
 
 This task is deprecated in VSTS and TFS 2018 and later. Use version 2.x or higher of the
-[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)
+[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)
 task together with [phases](../../process/phases.md)
 to run unit and functional tests on the universal agent.
 

--- a/docs/pipelines/tasks/test/visual-studio-test-agent-deployment.md
+++ b/docs/pipelines/tasks/test/visual-studio-test-agent-deployment.md
@@ -17,7 +17,7 @@ monikerRange: '>= tfs-2015'
 ::: moniker range=">= tfs-2018"
 
 This task is deprecated in VSTS and TFS 2018 and later. Use version 2.x or higher of the
-[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)
+[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)
 task together with [phases](../../process/phases.md)
 to run unit and functional tests on the universal agent.
 

--- a/docs/pipelines/test/associate-automated-test-with-test-case.md
+++ b/docs/pipelines/test/associate-automated-test-with-test-case.md
@@ -21,7 +21,7 @@ Consider using Visual Studio to associate automated tests with a test case when:
 * You created a manual test case that you later decide is a good test
   to automate, but you still want to be able to run that test as part of a test plan.
   Tests can be run in the CI/CD pipeline by choosing the test plan or test suite
-  in the settings of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task.
+  in the settings of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task.
   Automated tests can also be run from the **Test** hub in VSTS and TFS.
   If you are using [XAML builds](reference-qa.md#xaml-build) you can also
   [run these automated tests by using Microsoft Test Manager](run-automated-tests-with-microsoft-test-manager.md).
@@ -53,7 +53,7 @@ The process to associate an automated test with a test case is:
 If you are using Team Foundation Build and Release Management in
 VSTS or TFS (not a [XAML build](reference-qa.md#xaml-build)), you can run associated tests in the 
 Build and Release pipeline by using the
-[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task.
+[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task.
 You _cannot_ run tests on-demand using Microsoft Test Manager (MTM) unless you are using a [XAML build](reference-qa.md#xaml-build). 
 
 The parameters in a test case are not used by any automated test that

--- a/docs/pipelines/test/collect-screenshots-and-video.md
+++ b/docs/pipelines/test/collect-screenshots-and-video.md
@@ -57,7 +57,7 @@ screenshots, video, logs, and attachments is often useful to help troubleshoot f
 1. To collect video, specify the data collector you want to use in a [runsettings file](https://docs.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#video-data-collector).
    The video data collector captures a screen recording when tests are run.
 
-1. In the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task,
+1. In the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task,
    specify the location of the runsettings file.
 
    ![Specifying the location of the runsettings file](_img/runsettings-in-vs-task.png) 

--- a/docs/pipelines/test/getting-started-with-continuous-testing.md
+++ b/docs/pipelines/test/getting-started-with-continuous-testing.md
@@ -57,7 +57,7 @@ solution - on the same build machine.
    ![Build definition: customize unit test run](_img/getting-started-with-continuous-testing/edit-unit-test-task.png)
 
    The Visual Studio Test task version 2 supports [Test Impact Analysis](test-impact-analysis.md).
-   For information about all the task settings, see [Visual Studio Test task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md).
+   For information about all the task settings, see [Visual Studio Test task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md).
 
    [How do I pass parameters to my test code from a build pipeline?](reference-qa.md#pass-params)
 

--- a/docs/pipelines/test/reference-qa.md
+++ b/docs/pipelines/test/reference-qa.md
@@ -105,7 +105,7 @@ after the load tests have run and before the app is swapped from staging to prod
 to pass values as parameters to your test code. For example, in a release that contains
 several environments, you can pass the appropriate app URL to each the test tasks in each one.
 The runsettings file and matching parameters must be specified in the
-[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task.  
+[Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task.  
 
 ![Passing parameters to test code in a build or release pipeline](_img/pass-params-to-test-code.png)
 

--- a/docs/pipelines/test/run-automated-tests-from-test-hub.md
+++ b/docs/pipelines/test/run-automated-tests-from-test-hub.md
@@ -104,7 +104,7 @@ You will need:
 
    ![Specifying the properties for the Visual Studio Test task](_img/run-automated-tests-from-test-hub/run-auto-tests-from-hub-06.png)
 
-   For information about the option settings of the Visual Studio Test task, see [Visual Studio Test task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md).
+   For information about the option settings of the Visual Studio Test task, see [Visual Studio Test task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md).
 
 1. Choose the **Agent phase** item and verify that the deployment queue
    is set to the one containing the machines where you want to run the

--- a/docs/pipelines/test/run-tests-in-parallel.md
+++ b/docs/pipelines/test/run-tests-in-parallel.md
@@ -54,7 +54,7 @@ Parallel Test Execution is **not** supported in the following cases:
 
 Configure a [.runsettings file](https://docs.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file)
 in the app source repository for Visual Studio IDE or the CLI, and in VSTS when using
-version 1.x of the  [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)
+version 1.x of the  [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)
 task.
 
 <a name="runsettings"></a>
@@ -88,7 +88,7 @@ For the CLI, **vstest.console.exe** supports a **/Parallel** command line switch
 ## Enable parallel tests in VSTS with VS Test task v2.x
 
 Enable parallel test execution by setting the **Run Tests in Parallel...** checkbox
-in the settings for the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task.
+in the settings for the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task.
 
 ![Using parallel execution in VSTS](_img/run-tests-in-parallel/parallel-vsts.png)
 

--- a/docs/pipelines/test/set-up-continuous-test-environments-builds.md
+++ b/docs/pipelines/test/set-up-continuous-test-environments-builds.md
@@ -51,7 +51,7 @@ to install your agents.
 
 As an alternative, consider:
 
-* If you use version 2.x or higher of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)
+* If you use version 2.x or higher of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)
   task you can deploy and run unit and functional tests without requiring the **Deploy Test Agent** and **Run Functional Tests** tasks,
   and run tests on platforms that don't have Visual Studio installed by using the 
   [Visual Studio Test Platform](https://blogs.msdn.microsoft.com/devops/2016/07/25/evolving-the-visual-studio-test-platform-part-1/). 

--- a/docs/pipelines/test/set-up-continuous-testing-builds.md
+++ b/docs/pipelines/test/set-up-continuous-testing-builds.md
@@ -18,7 +18,7 @@ monikerRange: '>= tfs-2015'
 
 Find problems early after changes are checked in and built by running continuous tests using Visual Studio Team Services (VSTS) or Team Foundation Server (TFS).
 
-**NOTE**: You can use version 2.x or higher of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task to deploy and run
+**NOTE**: You can use version 2.x or higher of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task to deploy and run
 unit and functional tests without requiring the **Deploy Test Agent** and **Run Functional Tests** tasks,
 and run tests on platforms that don't have Visual Studio installed by using the 
 [Visual Studio Test Platform](https://blogs.msdn.microsoft.com/devops/2016/07/25/evolving-the-visual-studio-test-platform-part-1/). 
@@ -80,7 +80,7 @@ For more details, see [Testing with unified agents and phases](test-with-unified
 
 ## Set up test deployment for your build
 
-**NOTE**: You can use version 2.x of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task to deploy and run
+**NOTE**: You can use version 2.x of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task to deploy and run
 unit and functional tests without requiring the **Deploy Test Agent** and **Run Functional Tests** tasks,
 and run tests on platforms that don't have Visual Studio installed by using the 
 [Visual Studio Test Platform](https://blogs.msdn.microsoft.com/devops/2016/07/25/evolving-the-visual-studio-test-platform-part-1/). 
@@ -131,7 +131,7 @@ If you want to use the **Deploy Test Agent** and **Run Functional Tests** tasks:
 
 ## See also
 
-* [Visual Studio Test task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)
+* [Visual Studio Test task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)
 * [Visual Studio Test Platform](https://blogs.msdn.microsoft.com/devops/2016/07/25/evolving-the-visual-studio-test-platform-part-1/)
 * [Set up environments for continuous testing with your builds](set-up-continuous-test-environments-builds.md)
 * [Review continuous test results after a build](review-continuous-test-results-after-build.md)

--- a/docs/pipelines/test/test-impact-analysis.md
+++ b/docs/pipelines/test/test-impact-analysis.md
@@ -23,7 +23,7 @@ This slows down the frequency of integrations, and ultimately defeats the purpos
 In order to have a CI definition that completes quickly, some teams defer the execution of their longer running tests to a separate stage in the pipeline.
 However, this only serves to further defeat continuous integration.
 
-Instead, [enable Test Impact Analysis (TIA)](#enabletia) when using the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)
+Instead, [enable Test Impact Analysis (TIA)](#enabletia) when using the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)
 task in a build definition. TIA performs incremental validation by automatic test selection.
 It will automatically select only the subset of tests required to validate the code being committed.
 For a given code commit entering the CI/CD pipeline, TIA will select and run only the relevant tests required to validate that commit.
@@ -47,7 +47,7 @@ However, be aware of the following caveats when using TIA with Visual Studio 201
 At present, TIA is supported for:
 
 * TFS 2017 Update 1 onwards, and VSTS
-* Version 2.* of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task in the build definition
+* Version 2.* of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task in the build definition
 * Build vNext, with multiple VSTest Tasks
 * VS2015 Update 3 onwards on the build agent
 * Local and hosted build agents
@@ -72,7 +72,7 @@ At present, TIA is **not** supported for:
 
 ## Enable Test Impact Analysis
 
-TIA is supported through Version 2.* of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md) task.
+TIA is supported through Version 2.* of the [Visual Studio Test](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md) task.
 If your app is a single tier application, all you need to do is to check **Run only impacted tests** in the task UI.
 The Test Impact data collector is automatically configured. No additional steps are required.
 

--- a/docs/pipelines/test/test-with-unified-agent-and-phases.md
+++ b/docs/pipelines/test/test-with-unified-agent-and-phases.md
@@ -26,7 +26,7 @@ it works in a range of scenarios.
 For more information about the tasks see:
 
 * [Visual Studio Test version 1](https://github.com/Microsoft/vsts-tasks/blob/releases/m109/Tasks/VsTest/README.md)
-* [Visual Studio Test version 2](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTest/README.md)
+* [Visual Studio Test version 2](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VsTestV2/README.md)
 
 You select the [specific version](../../pipelines/process/tasks.md#task-versions)
 of a task you want to use in the **Version** list at the top


### PR DESCRIPTION
The folder was renamed in the GH project so they were all 404ing.
There was a case where there was an explicit reference to the V1, but it used a specific release branch, so it was still working.