### PR TITLE
fix: SqlAzureDacpacDeployment renamed to V1 on GH

### DIFF
--- a/docs/pipelines/apps/cd/sql-server-actions.md
+++ b/docs/pipelines/apps/cd/sql-server-actions.md
@@ -215,6 +215,6 @@ sqlpackage.exe /Action:Script /?
 
 * [Deploy your database to Azure SQL Database using DACPACs](deploy-dacpac-sqlpackage.md)
 * [Deploy your database to Azure SQL database using SQL scripts](deploy-database-sqlscripts.md)
-* [SQL Azure Dacpac Deployment task on GitHub](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/SqlAzureDacpacDeployment)
+* [SQL Azure Dacpac Deployment task on GitHub](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/SqlAzureDacpacDeploymentV1)
 
 [!INCLUDE [rm-help-support-shared](../../_shared/rm-help-support-shared.md)]

--- a/docs/pipelines/library/azure-stack.md
+++ b/docs/pipelines/library/azure-stack.md
@@ -49,7 +49,7 @@ The following Azure tasks are validated with Azure Stack:
 * [Azure Resource Group Deployment](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzureResourceGroupDeploymentV2)
 * [Azure App Service Deploy](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzureRmWebAppDeployment)
 * [Azure App Service Manage](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzureAppServiceManage) 
-* [Azure SQL Database Deployment](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/SqlAzureDacpacDeployment)
+* [Azure SQL Database Deployment](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/SqlAzureDacpacDeploymentV1)
 
 ### How do I resolve SSL errors during deployment?
 

--- a/release-notes/2016/feb-16-team-services.md
+++ b/release-notes/2016/feb-16-team-services.md
@@ -97,7 +97,7 @@ Important diagnostics information such as test errors and status messages from t
 
 ####Azure SQL Database Deployment task
 
-Deploy an Azure SQL Database to an existing Azure SQL Server. The Azure SQL Database deployment task now supports both Azure Classic and Azure Resource Manager connection. You can find more details at the [GitHub project](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/SqlAzureDacpacDeployment/README.md).
+Deploy an Azure SQL Database to an existing Azure SQL Server. The Azure SQL Database deployment task now supports both Azure Classic and Azure Resource Manager connection. You can find more details at the [GitHub project](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/SqlAzureDacpacDeploymentV1/README.md).
 
 ####Delete Test Plan
 


### PR DESCRIPTION
Think some stuff got lost in the folder rename and rebase from your private repo, so this partially re-does #841