### PR TITLE
Remove duplicate words

### DIFF
--- a/docs/_shared/keyboard-shortcuts/work-backlog-shortcuts.md
+++ b/docs/_shared/keyboard-shortcuts/work-backlog-shortcuts.md
@@ -19,7 +19,7 @@ You can use the following keyboard shortcuts when working in the **Work** hub, *
 <br/>
 &nbsp;&nbsp;&nbsp;**m,b**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Move item to backlog<br/>
 &nbsp;&nbsp;&nbsp;**m,i**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Move item to current iteration<br/>
-&nbsp;&nbsp;&nbsp;**m,n**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Move item to to next iteration<br/>
+&nbsp;&nbsp;&nbsp;**m,n**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Move item to next iteration<br/>
 <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**n**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Open new item panel<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Ins**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Add child<br/>

--- a/docs/accounts/account-preferences.md
+++ b/docs/accounts/account-preferences.md
@@ -26,7 +26,7 @@ Locale settings include language, date and time pattern, time zone, and user int
 
 ## Change profile settings (VSTS)
 
-To change your your account information, open your account menu.
+To change your account information, open your account menu.
 
 ![VSTS, My Profile link on Account menu](_img/account-prefs/open-profile-team-services.png)
 

--- a/docs/extend/reference/client/api/TFS/TestManagement/Contracts/TestConfiguration.md
+++ b/docs/extend/reference/client/api/TFS/TestManagement/Contracts/TestConfiguration.md
@@ -34,7 +34,7 @@ Module path: `TFS/TestManagement/Contracts`
 
 * `project`: [ShallowReference](../../../TFS/TestManagement/Contracts/ShallowReference.md). Project to which the configuration belongs
 
-* `revision`: number. Revision of the the configuration
+* `revision`: number. Revision of the configuration
 
 * `state`: [TestConfigurationState](../../../TFS/TestManagement/Contracts/TestConfigurationState.md). State of the configuration
 

--- a/docs/git/_shared/find-url.md
+++ b/docs/git/_shared/find-url.md
@@ -16,7 +16,7 @@ A: You'll find it in the code hub in your team project.
 
  ![Team project home page, code explorer](_img/code-explorer.png)   
 
-3. Select the the repository and click on the **clone** action to get the URL.   
+3. Select the repository and click on the **clone** action to get the URL.   
 
  ![Team project home page, code explorer, clone selected to show the URL](_img/clone-url.png)
 

--- a/docs/git/how-to/require-branch-folders.md
+++ b/docs/git/how-to/require-branch-folders.md
@@ -39,7 +39,7 @@ As an example, we'll set our repository to enforce the following rules:
 ## Preparation
 
 * You will need the Team Foundation version control command (`tf.exe`) on your computer.
-Run a Visual Studio Developer Command Prompt (in Windows, choose **Start**, choose **Visual Studio**, then choose the the **Developer Command Prompt**).
+Run a Visual Studio Developer Command Prompt (in Windows, choose **Start**, choose **Visual Studio**, then choose the **Developer Command Prompt**).
 * You will need the URL of your account or collection, the name of the project, and the name of the repository. For this example, we'll use `https://fabrikam-fiber.visualstudio.com`, `FabrikamProject`, and `FabrikamRepo`.
 
 ## Enforce permissions

--- a/docs/git/pull-requests-overview.md
+++ b/docs/git/pull-requests-overview.md
@@ -91,7 +91,7 @@ You want reviewers that will know how your code works, but try to also include d
 Provide a clear description of your changes and provide a build of your code that has your fix or feature running in it.
 
 Reviewers should make an effort to provide feedback on changes they don't agree with.
-Identify the the issue and give a specific suggestions on what you would do differently.
+Identify the issue and give a specific suggestions on what you would do differently.
 This feedback has clear intent and is easy for the owner of the pull request to understand.
 The pull request owner should reply to the comments, accepting the suggestion or explaining why the suggested change isn't ideal.
 Sometimes a suggestion is good, but the changes are outside the scope of the pull request.

--- a/docs/git/tutorial/branches.md
+++ b/docs/git/tutorial/branches.md
@@ -31,7 +31,7 @@ In this tutorial you learn:
 
 > [!div class="checklist"]
 > * How are Git branches created?
-> * How to to create a branch
+> * How to create a branch
 > * How to delete a branch
 > * How to use branches
 

--- a/docs/git/tutorial/commits.md
+++ b/docs/git/tutorial/commits.md
@@ -88,7 +88,7 @@ compatibility with other Git tools.</blockquote>
    
 Stage multiple files or folders by selecting them then right-clicking and choosing **Stage** or by dragging and dropping files from the **Changes** list into the **Staged Changes** list. 
 
-Ignore files by right-clicking and selecting **Ignore this local item** or **Ignore this extension**. This adds an entry to the the file to the .gitignore file in your local repo. If the ignored file was added 
+Ignore files by right-clicking and selecting **Ignore this local item** or **Ignore this extension**. This adds an entry to the .gitignore file in your local repo. If the ignored file was added 
 to your repo in an earlier commit, ignoring the file will not remove it from the **Changes** list. See [excluding and ignoring files section](ignore-files.md) for more information on how to ignore files already tracked by Git.   
 
 # [Command Line](#tab/command-line)

--- a/docs/integrate/ide/extensions/help/help.md
+++ b/docs/integrate/ide/extensions/help/help.md
@@ -20,7 +20,7 @@ If you don't find an answer to your question here, try the [ExtendVS Gitter foru
 
 ## General
 <a name="marketplace"></a>
-#### Q: How do I add my extension the the Visual Studio Marketplace?
+#### Q: How do I add my extension to the Visual Studio Marketplace?
 
 A: The Visual Studio Marketplace is currently in preview. Continue managing your Visual Studio extensions through the [Gallery](https://visualstudiogallery.msdn.microsoft.com/). Once the Marketplace is ready, your extension will be automatically migrated to the Marketplace.
 

--- a/docs/integrate/previous-apis/dashboard/widgets.md
+++ b/docs/integrate/previous-apis/dashboard/widgets.md
@@ -138,7 +138,7 @@ PATCH https://{account}.VisualStudio.com/DefaultCollection/{project}/{teamId}/_a
 
 ## Replace a widget
 <a id="ReplaceWidget"></a>
-Replace the the widget.
+Replace the widget.
 
 Note the following: 
 * You must populate the eTag field of the **Widget** to participate in widget settings versioning.

--- a/docs/integrate/previous-apis/git/diffs.md
+++ b/docs/integrate/previous-apis/git/diffs.md
@@ -16,7 +16,7 @@ ms.date: 08/23/2016
 [!INCLUDE [API_version](../_data/version.md)]
 
 Diffs compare a target version with a base version and return a list of items that are only in the target version.
-If either the target or base version isn't specified, the the default branch is used.
+If either the target or base version isn't specified, the default branch is used.
 
 [!INCLUDE [GET_STARTED](../_data/get-started.md)]
 

--- a/docs/integrate/previous-apis/notification/contracts.md
+++ b/docs/integrate/previous-apis/notification/contracts.md
@@ -697,7 +697,7 @@ Conditions a subscription must match to qualify for the query result set. Not al
 | Field        | Type      | Notes
 | :----------- | :-------- | :----------
 | <code>filter</code> | [ISubscriptionFilter](#ISubscriptionFilter) | Filter conditions that matching subscriptions must have. Typically only the filter's type and event type are used for matching.
-| <code>flags</code> | [SubscriptionFlags](#SubscriptionFlags) | Flags to specify the the type subscriptions to query for.
+| <code>flags</code> | [SubscriptionFlags](#SubscriptionFlags) | Flags to specify the type of subscriptions to query for.
 | <code>scope</code> | string | Scope that matching subscriptions must have.
 | <code>subscriberId</code> | GUID | ID of the subscriber (user or group) that matching subscriptions must be subscribed to.
 | <code>subscriptionId</code> | string | ID of the subscription to query for.

--- a/docs/integrate/previous-apis/notification/contracts.md
+++ b/docs/integrate/previous-apis/notification/contracts.md
@@ -833,4 +833,4 @@ This is the type used for firing notifications intended for the subsystem in the
 | <code>artifactUris</code> | array (string) | Optional: A list of artifacts referenced or impacted by this event.
 | <code>data</code> | object | Required: The event payload.  If Data is a string, it must be in Json or XML format.  Otherwise it must have a serialization format attribute.
 | <code>eventType</code> | string | Required: The name of the event.  This event must be registered in the context it is being fired.
-| <code>scopes</code> | array ([EventScope](#EventScope)) | Optional: A list of scopes which are are relevant to the event.
+| <code>scopes</code> | array ([EventScope](#EventScope)) | Optional: A list of scopes which are relevant to the event.

--- a/docs/integrate/previous-apis/rm/contracts.md
+++ b/docs/integrate/previous-apis/rm/contracts.md
@@ -999,7 +999,7 @@ Class to represent favorite entry
 | Field        | Type      | Notes
 | :----------- | :-------- | :----------
 | <code>data</code> | string | Application specific data for the entry
-| <code>id</code> | GUID | Unique Id of the the entry
+| <code>id</code> | GUID | Unique Id of the entry
 | <code>name</code> | string | Display text for favorite entry
 | <code>type</code> | string | Application specific favorite entry type. Empty or Null represents that Favorite item is a Folder
 

--- a/docs/integrate/previous-apis/security/permissions.md
+++ b/docs/integrate/previous-apis/security/permissions.md
@@ -121,6 +121,6 @@ DELETE https://{instance}/_apis/permissions/{securitynamespace}/{permissions}/?t
 | permissions       | int      |         | The permission bits to remove from the ACE's allow and deny bitmasks.
 | Query 
 | token             | string   |         | The token whose ACL contains the ACE to be modified.
-| descriptor        | IdentityDescriptor |         | The descriptor of the ACE to to be modified.
+| descriptor        | IdentityDescriptor |         | The descriptor of the ACE to be modified.
 
 [!code-REST [DELETE_permissions](./_data/DELETE__permissions__securityNamespaceId__4__token-_token1__descriptor-_descriptor_.json)]

--- a/docs/integrate/previous-apis/security/permissions.md
+++ b/docs/integrate/previous-apis/security/permissions.md
@@ -70,7 +70,7 @@ GET https://{instance}/_apis/permissions/{securitynamespace}/{permissions}/?api-
 | api-version       | string   |         | [Version](../../concepts/rest-api-versioning.md) of the API to use. Works with Version 2.2 and above.
 | tokens            | string   |         | String containing a list of tokens (separated by the delimiter) on which to check permissions.
 | alwaysAllowAdministrators | bool     |         | True if members of the Administrators group should always pass the security check.
-| delimiter         | char     | ,       | The delimiter to use when encoding the the list of tokens on the wire as a single string.
+| delimiter         | char     | ,       | The delimiter to use when encoding the list of tokens on the wire as a single string.
 
 [!code-REST [GET_permissions_plural](./_data/GET__permissions__securityNamespaceId__8__api-version-2.2_tokens-_token1_,_token2_,_token3__alwaysAllowAdministrators-False.json)]
 

--- a/docs/integrate/previous-apis/work/team-field-values.md
+++ b/docs/integrate/previous-apis/work/team-field-values.md
@@ -15,7 +15,7 @@ ms.date: 08/04/2016
 # Team field values
 [!INCLUDE [API_version](../_data/version2-preview1.md)]
 
-The team field is used to identify which work items belong to your team. By default, Area Path is the team field, but it can be any field. Use this API to get and set the the team field values.
+The team field is used to identify which work items belong to your team. By default, Area Path is the team field, but it can be any field. Use this API to get and set the team field values.
 
 [!INCLUDE [GET_STARTED](../_data/get-started.md)]
 

--- a/docs/notifications/collaborate-in-a-team-room.md
+++ b/docs/notifications/collaborate-in-a-team-room.md
@@ -7,7 +7,8 @@ ms.prod: devops
 ms.topic: conceptual
 ms.assetid: 5f3d7c83-15bd-4176-b594-3e2ddc1afd6b 
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.date: 02/20/2018
 monikerRange: '>= tfs-2013 <=tfs-2017'
 ---
@@ -99,7 +100,7 @@ Adding events lets your team know when builds finish, source code is checked in,
 | Build completions | Anytime a build completes for a specified build definition    |  
 | Code changes | Anytime code is pushed or checked in from a specified repo or branch   |  
 | Work item updates | Anytime a work item is added or modified in or under a specified area path   |  
-| Code reviews| Anytime a code review is created in or under a specified area area path  |  
+| Code reviews| Anytime a code review is created in or under a specified area path  |  
 | Pull requests | Anytime a pull request is created for a specified repo or branch   |  
   
 

--- a/docs/notifications/manage-personal-notifications.md
+++ b/docs/notifications/manage-personal-notifications.md
@@ -37,7 +37,7 @@ From the web portal, click the icon with your initials or picture icon, and sele
 
 <img src="_img/unsubscribe-open-notification-settings.png" alt="Open personal notification settings" style="border: 2px solid #C3C3C3;" />
 
-This view shows all subscriptions that you have created or that have been created by an administrator. Subscriptions let you control what you are notified about. Those notifications you're subscribed to are indicated with the the State as **On**. 
+This view shows all subscriptions that you have created or that have been created by an administrator. Subscriptions let you control what you are notified about. Those notifications you're subscribed to are indicated with the State as **On**. 
 
 <img src="_img/unsubscribe-personal-notifications.png" alt="Personal notification subscriptions" style="border: 2px solid #C3C3C3;" />
 

--- a/docs/notifications/unsubscribe-default-notification.md
+++ b/docs/notifications/unsubscribe-default-notification.md
@@ -26,7 +26,7 @@ You start by opening your personal notification settings. If you don't have a te
 
 	<img src="_img/unsubscribe-open-notification-settings.png" alt="Open personal notification settings" style="border: 2px solid #C3C3C3;" />
 
-	Those notifications you're subscribed to are indicated with the the State as **On**.  
+	Those notifications you're subscribed to are indicated with the State as **On**.  
 
 	<img src="_img/unsubscribe-personal-notifications.png" alt="Personal notification subscriptions" style="border: 2px solid #C3C3C3;" />
 

--- a/docs/organizations/security/about-security-roles.md
+++ b/docs/organizations/security/about-security-roles.md
@@ -1,7 +1,7 @@
 ---
 title: Understand how security roles work
 titleSuffix: VSTS & TFS
-description: Learn about security roles and where they are are used to manage permissions to select features and functions of TFS and VSTS
+description: Learn about security roles and where they are used to manage permissions to select features and functions of TFS and VSTS
 ms.technology: devops-security
 ms.assetid: 
 toc: show

--- a/docs/organizations/security/change-individual-permissions.md
+++ b/docs/organizations/security/change-individual-permissions.md
@@ -44,7 +44,7 @@ Create a custom security group at the project-level or the collection-level. The
 
     <img src="_img/add-users/choose-team-project-click-gear-icon.png" alt="VSTS, TFS 2017, Team Project hub, Click gear icon to open the Admin context" style="border: 1px solid #C3C3C3;" /> 
 
-2. Open the **Security** page and and choose **Create group** to open the dialog for adding a group.
+2. Open the **Security** page and choose **Create group** to open the dialog for adding a group.
 
     <img src="_img/change-individual-permissions/create-group-open-dialog.png" alt="Create security group at the account or collection level" style="border: 1px solid #C3C3C3;" /> 
 

--- a/docs/organizations/settings/work/custom-rules.md
+++ b/docs/organizations/settings/work/custom-rules.md
@@ -6,7 +6,8 @@ ms.technology: devops-agile
 ms.prod: devops
 ms.assetid: 17A6AF2C-81E9-4717-971E-2621613AEB31  
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 monikerRange: 'vsts'
 ms.topic: conceptual
 ms.date: 05/31/2018
@@ -25,9 +26,9 @@ With a custom rule, you can define a number of actions based on specific conditi
 - When a change is made to the value of Release, then clear the value of "Milestone"     
 - When a change was made to the value of Remaining Work, then make Completed Work a required field
 - When the value of Approved is True, then make Approved By a required field 
-- When a user story is created, make make the following fields required: Priority, Risk, and  Effort
+- When a user story is created, make the following fields required: Priority, Risk, and  Effort
 
-[!INCLUDE [temp](../_shared/tip-formula-rule.md)]
+[!INCLUDEÂ [temp](../_shared/tip-formula-rule.md)]
 
 ## Rule composition  
 

--- a/docs/organizations/settings/work/inheritance-process-model.md
+++ b/docs/organizations/settings/work/inheritance-process-model.md
@@ -133,7 +133,7 @@ With a custom rule, you can define a number of actions based on specific conditi
 - When a change is made to the value of Release, then clear the value of "Milestone"     
 - When a change was made to the value of Remaining Work, then make Completed Work a required field
 - When the value of Approved is True, then make Approved By a required field 
-- When a user story is created, make make the following fields required: Priority, Risk, and  Effort
+- When a user story is created, make the following fields required: Priority, Risk, and  Effort
 
 [!INCLUDE [temp](../_shared/tip-formula-rule.md)]
 

--- a/docs/pipelines/build/artifacts.md
+++ b/docs/pipelines/build/artifacts.md
@@ -19,7 +19,7 @@ monikerRange: '>= tfs-2015'
 
 Artifacts are the files that you want your build to produce. Artifacts can be nearly anything your team needs to test or deploy your app. For example, you've got a .DLL and .EXE executable files and .PDB symbols file of a C# or C++ .NET Windows app.
 
-Release Management can pick up and use your build artifacts as part of of a continuous integration (CI)/ continuous deployment (CD) process. In this scenario, you're automatically building a web app with each commit using your CI build. Your CD release process picks up the .ZIP (ASP.NET or Node.js) or .WAR (Java) web deployment file. Your changes are automatically deployed to a test environment in Azure.
+Release Management can pick up and use your build artifacts as part of a continuous integration (CI)/ continuous deployment (CD) process. In this scenario, you're automatically building a web app with each commit using your CI build. Your CD release process picks up the .ZIP (ASP.NET or Node.js) or .WAR (Java) web deployment file. Your changes are automatically deployed to a test environment in Azure.
 
 ## Examples
 

--- a/docs/pipelines/tasks/utility/copy-files.md
+++ b/docs/pipelines/tasks/utility/copy-files.md
@@ -55,7 +55,7 @@ None
 <li>```**\*``` copies all files in the root folder and all files in all sub-folders.</li>
 <li>```**\bin\**``` copies all files recursively from any ```bin``` folder.</li>
 </ul>
-<p>The pattern is used to match only file paths, not folder paths. So you should specify patterns such as ```**\bin\**``` instead of of ```**\bin```.</p>
+<p>The pattern is used to match only file paths, not folder paths. So you should specify patterns such as ```**\bin\**``` instead of ```**\bin```.</p>
 <p>More examples are shown below.</p>
 </td>
 </tr>

--- a/docs/pipelines/tasks/utility/extract-files.md
+++ b/docs/pipelines/tasks/utility/extract-files.md
@@ -52,7 +52,7 @@ None
 <li>```**\*.tar``` extracts all .tar files in the root folder and sub-folders.</li>
 <li>```**\bin\*.7z``` extracts all ''.7z'' files in any sub-folder named bin.</li>
 </ul>
-<p>The pattern is used to match only archive file paths, not folder paths, and not archive contents to be extracted. So you should specify patterns such as ```**\bin\**``` instead of of ```**\bin```.</p>
+<p>The pattern is used to match only archive file paths, not folder paths, and not archive contents to be extracted. So you should specify patterns such as ```**\bin\**``` instead of ```**\bin```.</p>
 </td>
 </tr>
 <tr>

--- a/docs/pipelines/test/continuous-test-java.md
+++ b/docs/pipelines/test/continuous-test-java.md
@@ -81,7 +81,7 @@ include all the data from Details
 View, as well as automatically linking the build, 
 test run, and a generated title.
 
-![Creating actionable bugs that include all the data from from Details View](_img/continuous-test-java/continuous-test-java-05.png)
+![Creating actionable bugs that include all the data from Details View](_img/continuous-test-java/continuous-test-java-05.png)
 
 <a name="code-coverage"></a>
 ## Code coverage results

--- a/docs/pipelines/test/test-impact-analysis.md
+++ b/docs/pipelines/test/test-impact-analysis.md
@@ -131,7 +131,7 @@ When TIA opens a commit and sees an unknown file type, it falls back to running 
 To evaluate whether TIA is selecting the appropriate tests:
 
 * Manually validate the selection. A developer who knows how the SUT and tests are architected could manually validate the test selection using the [TIA reporting capabilities](#tiareports).
-* Run TIA selected tests and then all tests in sequence. In a build definition, use two test tasks - one that runs only impacted Tests (T1) and one that runs all tests (T2). If T1 passes, check that that T2 passes as well. If there was a failing test in T1, check that T2 reports the same set of failures.
+* Run TIA selected tests and then all tests in sequence. In a build definition, use two test tasks - one that runs only impacted Tests (T1) and one that runs all tests (T2). If T1 passes, check that T2 passes as well. If there was a failing test in T1, check that T2 reports the same set of failures.
 
 [More information about TIA advanced configuration](https://blogs.msdn.microsoft.com/devops/2017/06/13/accelerated-continuous-testing-with-test-impact-analysis-part-3/)
 

--- a/docs/project/navigation/keyboard-shortcuts.md
+++ b/docs/project/navigation/keyboard-shortcuts.md
@@ -161,7 +161,7 @@ Use these shortcuts when working in Team Explorer.
 
 <br/>
 **Ctrl+'**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Move focus to search box  
-**Alt+0**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Move focus to to top of page  
+**Alt+0**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Move focus to top of page  
 **Alt+1**&#8230;9&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Move focus to visible section [1 thru 9]   
 **Alt+**![Up/Down arrow](../../work/_img/icons/Arrow_Up.png)![ ](../../work/_img/icons/Arrow_Down.png)&nbsp;&nbsp;&nbsp;&nbsp;Move focus to next/previous section 
 

--- a/docs/report/dashboards/configure-burndown-burnup-widgets.md
+++ b/docs/report/dashboards/configure-burndown-burnup-widgets.md
@@ -6,7 +6,8 @@ ms.technology: devops-analytics
 ms.prod: devops
 ms.topic: tutorial
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 monikerRange: 'vsts'
 ms.date: 03/20/2018 
 ---
@@ -185,7 +186,7 @@ The Configuration dialog for the Burndown and Burnup widgets is the same. You co
 Check the boxes of the following options that you want to add to your chart.    
 * **Show burndown**: Displays both the historical and projected future burndown
 * **Show total scope**: Displays both the historical and projected scope increase
-* **Show completed work**: In addition to remaining work, it also displays completed work as as stack bar
+* **Show completed work**: In addition to remaining work, it also displays completed work as a stack bar
 * **Plot remaining using work item type color**: Displays remaining work based on the work item type color, rather than the default blue color. If multiple work items are included, then it stacks colors by work item type.
 
 ## Interpret a Burndown or Burnup widget chart

--- a/docs/report/dashboards/velocity-chart-data-store.md
+++ b/docs/report/dashboards/velocity-chart-data-store.md
@@ -7,7 +7,8 @@ ms.prod: devops
 ms.topic: tutorial
 ms.reviewer: greggboe
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 monikerRange: '>= tfs-2013'
 ms.date: 12/14/2017
 ---
@@ -45,7 +46,7 @@ Velocity will vary depending on team capacity, sprint over sprint. However, over
 
 1.	From the backlog page, open the velocity chart.  
 
-	![Click the the velocity chart in the upper right area of the page](_img/velocity-forecast-open-chart.png)  
+	![Click the velocity chart in the upper right area of the page](_img/velocity-forecast-open-chart.png)  
 
 	For charts to appear, your team must perform these activities: 
 	- Select sprints for your team  
@@ -76,7 +77,7 @@ For your team to gain the greatest utility from the velocity chart, follow these
 *	Define and size backlog items to [minimize variability](velocity-guidance.md).  
 *	Determine how your team wants to [treat bugs](../../work/customize/show-bugs-on-backlog.md). If your team chooses to treat bugs like requirements, bugs will show up on the backlog and be counted within the Velocity chart and forecasting. 
 *	[Set your team's area path](../../work/customize/set-area-paths.md). The forecast tool will forecast those items based on your team's default settings. These settings can specify to include items in area paths under the team's default or exclude them.     
-*	Don't  create a hierarchy of backlog items and bugs. The Kanban board, sprint backlog, and task board only show the last node in a hierarchy, called the leaf node. For example, if you link items within a hierarchy that is four levels deep, only the items at the fourth level appear on the Kanban board, sprint backlog, and task board. <br/>Instead of nesting requirements, bugs, and tasks, we recommend that you maintain a flat list”€only creating parent-child links one level deep between items. Use [Features to group requirements or user stories](../../work/backlogs/organize-backlog.md). You can quickly map stories to features, which creates parent-child links in the background.  
+*	Don't  create a hierarchy of backlog items and bugs. The Kanban board, sprint backlog, and task board only show the last node in a hierarchy, called the leaf node. For example, if you link items within a hierarchy that is four levels deep, only the items at the fourth level appear on the Kanban board, sprint backlog, and task board. <br/>Instead of nesting requirements, bugs, and tasks, we recommend that you maintain a flat list-only creating parent-child links one level deep between items. Use [Features to group requirements or user stories](../../work/backlogs/organize-backlog.md). You can quickly map stories to features, which creates parent-child links in the background.  
 *	At the end of the sprint, update the status of those backlog items that the team has fully completed. Incomplete items should be moved back to the product backlog and considered in a future sprint planning meeting.   
 
 ## Add other teams

--- a/docs/report/extend-analytics/odata-query-guidelines.md
+++ b/docs/report/extend-analytics/odata-query-guidelines.md
@@ -322,7 +322,7 @@ To resolve this problem, use the OData batch endpoint as explained in the specif
 
 We restrict use of the batch endpoint from handling a batch of multiple requests. A single request can still have only one query. If you try to send a batch of several queries, the operation will fail with the following error message. The only solution is to split queries into multiple requests.
 
-> *The Analytics Service doesn€™t support processing of multiple operations which the current batch message contains. The Analytics Service uses OData batch in order to support POST requests, but requires you limit the operation to a single request.*
+> *The Analytics Service doesn't support processing of multiple operations which the current batch message contains. The Analytics Service uses OData batch in order to support POST requests, but requires you limit the operation to a single request.*
 
 <a name="question-41401"></a>
 ### âŒ AVOID creating very long queries
@@ -580,7 +580,7 @@ https://{account}.analytics.visualstudio.com/_odata/v1.0/WorkItems?
 ```
 
 > [!IMPORTANT]
-> Property `TagNames` has a length limit of 1024 characters. It contains contains a set of tags that fit within that limit. If a work item has many tags or the tags are very long, then `TagNames` will not contain the full set and `Tag` navigation property should be used instead.
+> Property `TagNames` has a length limit of 1024 characters. It contains a set of tags that fit within that limit. If a work item has many tags or the tags are very long, then `TagNames` will not contain the full set and `Tag` navigation property should be used instead.
 
 
 <a id="perf-case-sensitive"> </a>

--- a/docs/report/extend-analytics/odata-supported-features.md
+++ b/docs/report/extend-analytics/odata-supported-features.md
@@ -18,7 +18,7 @@ ms.date: 3/16/2018
 
 [!INCLUDE [temp](../../_shared/version-vsts-only.md)]
 
-This topic provides a summary of the OData features and functions supported or not supported by the Analytics Service for for Visual Studio Team Services (VSTS).
+This topic provides a summary of the OData features and functions supported or not supported by the Analytics Service for Visual Studio Team Services (VSTS).
 
 [!INCLUDE [temp](../_shared/analytics-preview.md)]
 

--- a/docs/report/powerbi/create-timeinstate-report.md
+++ b/docs/report/powerbi/create-timeinstate-report.md
@@ -470,7 +470,7 @@ IF (
 ## DAX functions
 Additional information is provided in this section for the DAX functions used to created the calculated columns and measure added in this article. 
 
-* [`CALCULATE`](https://msdn.microsoft.com/query-bi/dax/calculate-function-dax): This function is the the basis for nearly all examples. The basic structure is an expression followed by a series of filters which are applied to the expression.     
+* [`CALCULATE`](https://msdn.microsoft.com/query-bi/dax/calculate-function-dax): This function is the basis for nearly all examples. The basic structure is an expression followed by a series of filters which are applied to the expression.     
 
 * [`COUNTROWS`](https://msdn.microsoft.com/en-us/query-bi/dax/countrows-function-dax): This function, `COUNTROWS ( 'View Name' )`, simply counts the number of rows which remain after the filters are applied. 
 	

--- a/docs/test/create-test-cases.md
+++ b/docs/test/create-test-cases.md
@@ -51,7 +51,7 @@ See [Default manual testing permissions and access](manual-test-permissions.md).
    Now you've created a test case that you can run.
 
 >Test iterations are design to support data-driven scenarios, not workflow-driven scenarios.
-From a best practice perspective, if you have two test scenarios where the the workflows are
+From a best practice perspective, if you have two test scenarios where the workflows are
 different, consider creating separate test cases. 
 
 <a name="assigncase"></a>

--- a/docs/tfvc/_shared/find-url.md
+++ b/docs/tfvc/_shared/find-url.md
@@ -16,7 +16,7 @@ A: You'll find it in the code hub in your team project.
 
  ![Team project home page, code explorer](_img/code-explorer.png)
 
-3. Select the the repository and click on the **clone** action to get the URL.
+3. Select the repository and click on the **clone** action to get the URL.
 
  ![Team project home page, code explorer, clone selected to show the URL](_img/clone-url.png)
 

--- a/docs/tfvc/rename-move-files-folders.md
+++ b/docs/tfvc/rename-move-files-folders.md
@@ -41,7 +41,7 @@ Move these files with [Solution Explorer](https://docs.microsoft.com/en-us/visua
 
 ### Fix the outcome after you rename an item in your operating system
 
-You should avoid renaming items managed by TFVC using your operating system (for example, using Windows File Explorer, or the **rename** command in the Windows command prompt). When you have used your operating system to rename an item in in a [local workspace](decide-between-using-local-server-workspace.md), Visual Studio detects the change as two changes: an add and a delete. You can join the two actions into a rename action.
+You should avoid renaming items managed by TFVC using your operating system (for example, using Windows File Explorer, or the **rename** command in the Windows command prompt). When you have used your operating system to rename an item in a [local workspace](decide-between-using-local-server-workspace.md), Visual Studio detects the change as two changes: an add and a delete. You can join the two actions into a rename action.
 
 > [!NOTE]
 > Git version control users can move and rename files from the command line or Windows Explorer without this concern. The changes will be reflected in Team Explorer.

--- a/docs/tfvc/use-team-foundation-version-control-commands.md
+++ b/docs/tfvc/use-team-foundation-version-control-commands.md
@@ -21,7 +21,7 @@ You can use version control commands to do nearly all tasks you can do in Visual
 
 ## Run a command
 
-To launch the Visual Studio command prompt, from Windows **Start**, choose **Visual Studio 2015**,   then choose the the **Developer Command Prompt for V2015** shortcut.
+To launch the Visual Studio command prompt, from Windows **Start**, choose **Visual Studio 2015**,   then choose the **Developer Command Prompt for V2015** shortcut.
 
 > Visual Studio 2017 users: The tf.exe binary is no longer in a fixed location in the Visual Studio install path as in previous releases (for example, C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE). Scripts using tf.exe should not hardcode a path to the file based on the Visual Studio 2017 install path.
 

--- a/docs/work/backlogs/add-work-items.md
+++ b/docs/work/backlogs/add-work-items.md
@@ -165,7 +165,7 @@ When you want to track the progress of a single work item, click the ![Follow ic
 
 You'll only receive notifications when other members of your team modifies the work item, such as adding to the discussion, changing a field value, or adding an attachment. 
 
-Notifications are sent to your preferred email address, which which [you can change from your account preferences](../../notifications/change-email-address.md).  
+Notifications are sent to your preferred email address, which [you can change from your account preferences](../../notifications/change-email-address.md).  
 
 To stop following changes, click the ![Following icon](../../work/_img/icons/following-icon.png)  icon.
  

--- a/docs/work/customize/customize-cards.md
+++ b/docs/work/customize/customize-cards.md
@@ -8,7 +8,8 @@ ms.technology: devops-agile
 ms.prod: devops
 ms.assetid: 951A73EA-7411-4A2A-B3F0-ACBBC7EFC68F
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: conceptual
 monikerRange: '>= tfs-2013'
 ms.date: 03/20/2018
@@ -75,7 +76,7 @@ Another handy feature is to simply update a field without having to open the wor
 
 This quick update feature is particularly useful when you need to update a number of work items at once. For example, you can add estimates for backlog items on the Kanban board or update remaining work on the task board. 
 
-To change the title, click the pencil icon in the upper-right corner. To add tags, double-click the work item to open it. And, just a reminder, you can't change the IDs for a work work item, not from the card and not from within the form. 
+To change the title, click the pencil icon in the upper-right corner. To add tags, double-click the work item to open it. And, just a reminder, you can't change the IDs for a work item, not from the card and not from within the form. 
 
 To customize cards on the Kanban board, see [Change how cards display on the Kanban board](#kanban-board). To customize task board cards, see [Change how cards display on the task board](#task-board).  
 

--- a/docs/work/customize/reference/layout-xml-element-reference.md
+++ b/docs/work/customize/reference/layout-xml-element-reference.md
@@ -6,7 +6,8 @@ ms.prod: devops
 ms.technology: devops-agile
 ms.assetid: 8898c116-62f8-416f-af33-90c389a038bb
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: reference
 monikerRange: '>= tfs-2013 <= tfs-2015'
 ms.date: 02/14/2017
@@ -22,7 +23,7 @@ ms.date: 02/14/2017
 >For an overview of process models, see [Customize your work tracking experience](../customize-work.md).   
 
 
-You can use the `Layout` element to define how the elements on the work item form appear. You can define more than one layout to support different clients, such as the Windows client for Visual Studio or the the web portal layout.  
+You can use the `Layout` element to define how the elements on the work item form appear. You can define more than one layout to support different clients, such as the Windows client for Visual Studio or the web portal layout.  
   
 To add elements to a form, you modify the definition for a work item type. See [Modify or add a custom work item type](../add-modify-wit.md).  
   

--- a/docs/work/customize/reference/linkscontroloptions-elements.md
+++ b/docs/work/customize/reference/linkscontroloptions-elements.md
@@ -6,7 +6,8 @@ ms.prod: devops
 ms.technology: devops-agile
 ms.assetid: b43e4e57-3a42-4705-9e52-eec2f8fb5f72
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: reference
 monikerRange: '>= tfs-2013 <= tfs-2015'
 ms.date: 02/02/2017
@@ -133,7 +134,7 @@ These buttons become available only after you perform a specific action:
 -   The buttons to open the list of work items in a query (![Open in Query](_img/icon_openinquery.png "Icon_openInQuery")) and in a Microsoft Office client (![Open in Office](_img/wit_iconoffice.png "WIT_IconOffice")) become available only when at least one work item is listed in the links control tab.   
 -   The buttons to open a work item (![Open Work Item](_img/icon_openworkitem.png "Icon_openWorkItem")), edit a link (![Edit link](_img/icon_witlinkedit.png "Icon_WITLinkEdit")), and delete a link (![Delete link](_img/icon_witlinkdelete.png "Icon_WITLinkDelete")) become available only after you click one or more work items listed in the links control tab.  
   
-The links control that is displayed is the same for both the web portal and Team Explorer, except when it is configured to only render `Storyboard` links. In that case, the toolbar only contains those controls to add a new link, open the linked item, and delete the link. Also, the the web portal version displays the **Start Storyboarding** link within the control menu.  
+The links control that is displayed is the same for both the web portal and Team Explorer, except when it is configured to only render `Storyboard` links. In that case, the toolbar only contains those controls to add a new link, open the linked item, and delete the link. Also, the web portal version displays the **Start Storyboarding** link within the control menu.  
   
 ![Storyboard links control](_img/alm_twa_storyboard_linkscontrol.png "ALM_TWA_Storyboard_LinksControl")  
   

--- a/docs/work/customize/reference/specify-work-item-form-controls.md
+++ b/docs/work/customize/reference/specify-work-item-form-controls.md
@@ -5,7 +5,8 @@ ms.prod: devops
 ms.technology: devops-agile
 ms.assetid: eb87afdf-66f4-4607-94c9-3909fd208079
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.date: 06/16/2017
 ---
 
@@ -66,7 +67,7 @@ Specify the `String` control when you want to add a string field, such as used i
 <Control FieldName="Microsoft.VSTS.DocName" Type="FieldControl" Label="Vision Doc Location" LabelPosition="Left" />
 ```
 
-Specify the `PlainText` control when you want to capture text that that contains descriptions that may be larger than 255 characters.
+Specify the `PlainText` control when you want to capture text that contains descriptions that may be larger than 255 characters.
   
 ```
 <Control FieldName="System.Title" Type="FieldControl" Label="Title" LabelPosition="Left" />
@@ -83,9 +84,9 @@ Use the following syntax to add a Boolean field within the **FIELDS** section of
 
 ```
 <FIELD name="Triage" refname="Fabrikam.Triage" type="Boolean" >
- <DEFAULT from="value" value="False" />
-        <HELPTEXT>Triage work item</HELPTEXT>
-        </FIELD>
+  <DEFAULT from="value" value="False" />
+  <HELPTEXT>Triage work item</HELPTEXT>
+</FIELD>
 ```
 
 And then add the following syntax within the **FORM** section to have the field appear on the form. 

--- a/docs/work/customize/reference/use-categories-to-group-work-item-types.md
+++ b/docs/work/customize/reference/use-categories-to-group-work-item-types.md
@@ -5,7 +5,8 @@ ms.prod: devops
 ms.technology: devops-agile
 ms.assetid: 2fc6c411-89a9-4af5-8dd3-b2d4c2ecf540
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.date: 04/04/2017
 ---
 
@@ -59,7 +60,7 @@ You use categories to accomplish the following operations:
 -   Test Suite Category  
 -   Hidden Types Category  
   
-Most of these categories are self-explanatory, and most only contain one WIT within the category. The exception to this rule is the Hidden Types Category.  
+Most of these categories are self-explanatory, and mostly contain one WIT within the category. The exception to this rule is the Hidden Types Category.  
   
 If you have created WITs that act in similar ways and you want to treat them in similar ways as those defined by the above categories, then you will want to add them to the category. For example, if you have defined one or more types of bugs, then you might want to add those types to the Bug Category. In this way, the process configuration will automatically treat these bug types as they do the standard bug WIT. Or, you can customize the Requirement Category to include two or more WITs which will then appear on the product backlog.  
   

--- a/docs/work/customize/update-customized-process-template.md
+++ b/docs/work/customize/update-customized-process-template.md
@@ -6,7 +6,8 @@ ms.technology: devops-agile
 ms.prod: devops
 ms.assetid: 09A88E62-F887-4139-923E-FACE6D759F92  
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: conceptual
 monikerRange: '>= tfs-2013 <= tfs-2018'
 ms.date: 02/26/2018
@@ -107,7 +108,7 @@ Perform the following steps for each WIT that you add to your process template. 
 	
 	* Add custom WITs to the work tracking folder, and update the **WorkItems** definition file as needed. See [Add type definitions for work items to a process template](reference/process-templates/add-wit-definitions-process-template.md).
 	
-		If you want to use a customized WIT that contains the same name as those in the default process template, then make sure that you swap out the WIT definition files. If you want to use a customized WIT with a different name that that provided in the default process template, then you'll need to modify the categories and process configuration definition files prior to import to reflect the different naming.
+		If you want to use a customized WIT that contains the same name as those in the default process template, then make sure that you swap out the WIT definition files. If you want to use a customized WIT with a different name that provided in the default process template, then you'll need to modify the categories and process configuration definition files prior to import to reflect the different naming.
 		
 	* Apply customizations to the **Categories** definition file. 
 

--- a/docs/work/kanban/index.md
+++ b/docs/work/kanban/index.md
@@ -1,7 +1,7 @@
 ---
 title: Kanban board 
 titleSuffix: VSTS & TFS
-description: Index to topics for working with Kanban in in Visual Studio Team Services & Team Foundation Server   
+description: Index to topics for working with Kanban in Visual Studio Team Services & Team Foundation Server   
 ms.technology: devops-agile
 ms.prod: devops
 ms.assetid:  

--- a/docs/work/kanban/split-columns.md
+++ b/docs/work/kanban/split-columns.md
@@ -7,8 +7,10 @@ ms.technology: devops-agile
 ms.prod: devops
 ms.assetid: BD18A2A1-56C4-40F8-983C-012A407AC7BB
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: conceptual
 monikerRange: 'vsts || >= tfs-2015 <= tfs-2018'
 ms.date: 03/20/2018
@@ -68,7 +70,7 @@ Now that you understand how your team can use split columns, here's how to turn 
 2.	Select each column that you want to split. Before you split columns, you'll want to have [mapped each stage of your team's process to a Kanban column](add-columns.md).
 	
 > [!TIP]    
-> You can can filter queries and create charts using the [Board Column Done field](../track/query-by-workflow-changes.md#kanban_query_fields). 
+> You can filter queries and create charts using the [Board Column Done field](../track/query-by-workflow-changes.md#kanban_query_fields). 
 
 ::: moniker-end
 

--- a/docs/work/scale/review-team-plans.md
+++ b/docs/work/scale/review-team-plans.md
@@ -6,7 +6,8 @@ ms.technology: devops-agile
 ms.prod: devops
 ms.assetid: 3B41D55E-B7B1-41B1-B68F-7A83BA2890A5  
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: tutorial
 monikerRange: '>= tfs-2017'
 ms.date: 03/20/2018
@@ -179,7 +180,7 @@ To quickly change the cards to only show their Title, enter the keyboard shortcu
 
 ### Update the iteration for a backlog item 
 
-As changes occur to the schedule, you you can update the iteration for a backlog item by moving a card to a different iteration. This will help to drive alignment across your organization.
+As changes occur to the schedule, you can update the iteration for a backlog item by moving a card to a different iteration. This will help to drive alignment across your organization.
 
 ![Move a card to a different iteration](_img/plans_move1.png)
 

--- a/docs/work/scrum/forecast.md
+++ b/docs/work/scrum/forecast.md
@@ -6,7 +6,8 @@ ms.technology: devops-agile
 ms.prod: devops
 ms.assetid: C46ED4AA-4B8F-4D5D-BC51-52F6D67BF8C6
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: tutorial
 ms.date: 03/20/2018
 ---
@@ -38,7 +39,7 @@ To forecast your product backlog, perform the following actions:
 
 *	Open your product backlog. You can only forecast the product backlog of Stories, Backlog items, or Requirements.
 *	Set **Forecast** to **On** and enter your team's predicted velocity.If the Forecasting bar doesn't appear, set Parents to Hide. 
-*	Set **In progress** items to **Hide** to hide those items that that won't be counted in the forecast. The forecast tool ignores Scrum items set to Committed or Done and Agile and CMMI items set to Active, Resolved, or Completed. 
+*	Set **In progress** items to **Hide** to hide those items that won't be counted in the forecast. The forecast tool ignores Scrum items set to Committed or Done and Agile and CMMI items set to Active, Resolved, or Completed. 
 *	Select enough [future sprints for your team](../scale/set-team-defaults.md#activate) to forecast your entire product backlog.
 *	Check the results manually to understand discrepancies in what you expect and what the forecast tool displays.  
 *	Check the amount of effort (Effort, Story Points, or Size) forecasted per sprint. 

--- a/docs/work/tfs-ps-sync/field-mapping-xml-element-reference.md
+++ b/docs/work/tfs-ps-sync/field-mapping-xml-element-reference.md
@@ -6,7 +6,8 @@ ms.prod: devops
 ms.technology: devops-agile 
 ms.assetid: dfd7bc62-dd68-4412-a86d-5f82c3ad9af3
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: reference
 ms.date: 01/12/2017
 ---
@@ -44,7 +45,7 @@ ms.date: 01/12/2017
 > [!IMPORTANT]
 >  In most configurations, you should not remove the default field mappings because the synchronization process requires them. For example, do not remove the default mappings if your enterprise project plan maps to a team project that was created from a process template that is based on either the Microsoft Solutions Framework (MSF) for Agile Software Development or the Capability Maturity Model Integration (CMMI) Process Improvement.  
 >   
->  However, if your plan maps to a team project that was created using the Visual Studio Scrum process template, you may need to remove some of the default mappings. If your project collection contains only team projects that were created using the Scrum template, you may receive an error when you configure the two server products. For best results, add Completed Work (Microsoft.VSTS.Scheduling.CompletedWork) and Original Estimate (Microsoft.VSTS.Scheduling.OriginalEstimate) to the work items that you intend to map. Also, you will need to to remove the `<EMPTY />` workflow statements from the task type definition. For more information, see [Required Changes to Make When Mapping to a Team Project That Was Created From the Scrum Process Template](customize-field-mapping-tfs-project-server.md).  
+>  However, if your plan maps to a team project that was created using the Visual Studio Scrum process template, you may need to remove some of the default mappings. If your project collection contains only team projects that were created using the Scrum template, you may receive an error when you configure the two server products. For best results, add Completed Work (Microsoft.VSTS.Scheduling.CompletedWork) and Original Estimate (Microsoft.VSTS.Scheduling.OriginalEstimate) to the work items that you intend to map. Also, you will need to remove the `<EMPTY />` workflow statements from the task type definition. For more information, see [Required Changes to Make When Mapping to a Team Project That Was Created From the Scrum Process Template](customize-field-mapping-tfs-project-server.md).  
   
  The following table describes the default mappings that are assigned to fields in Team Foundation. You can specify how you want reference and mirror fields to be updated. You can set `OnConflict` to `PSWins` to overwrite the value in Team Foundation with the value from Project Server. If you leave the `OnConflict` attribute unspecified, the fields maintain different values. For more information, review the [Field Elements and Attributes](#feandattributes) table later in this topic.  
   

--- a/docs/work/tfs-ps-sync/register-pwa.md
+++ b/docs/work/tfs-ps-sync/register-pwa.md
@@ -1,12 +1,13 @@
 ---
 title: Register an instance of PWA  to TFS 
 titleSuffix: TFS 
-description: Register the instance of Project Web Access or Project Web App (PWA) to to support Team Foundation Server-Project Server integration 
+description: Register the instance of Project Web Access or Project Web App (PWA) to support Team Foundation Server-Project Server integration 
 ms.prod: devops
 ms.technology: devops-agile
 ms.assetid: 4093f721-e8ed-439b-9882-00fbb2ea430f
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: reference
 ms.date: 01/12/2017
 ---

--- a/docs/work/tfs-ps-sync/synchronize-tfs-project-server.md
+++ b/docs/work/tfs-ps-sync/synchronize-tfs-project-server.md
@@ -1,12 +1,13 @@
 ---
 title: Synchronize Team Foundation Server with Project Server 
 titleSuffix: TFS 
-description: Enable the data to flow from work items in Team Foundation Server to tasks in in Project Server  
+description: Enable the data to flow from work items in Team Foundation Server to tasks in Project Server  
 ms.prod: devops
 ms.technology: devops-agile
 ms.assetid: 4ec7be08-78e4-40be-81ae-4d2d81c49cd0
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.date: 05/18/2017 
 ms.topic: overview
 ---

--- a/docs/work/track/linking-attachments.md
+++ b/docs/work/track/linking-attachments.md
@@ -6,7 +6,8 @@ ms.technology: devops-agile
 ms.prod: devops
 ms.assetid: 219717a0-de6e-4f70-8558-54f813f82507
 ms.manager: douge
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: sample
 ms.date: 05/10/2017  
 ---
@@ -315,7 +316,7 @@ These buttons become available only after you perform a specific action:
 
 -   The buttons to open a work item (![](_img/link-controls-restrictions-field-reference/IC588293.png)), edit a link (![](_img/link-controls-restrictions-field-reference/IC588336.png)), and delete a link (![](_img/link-controls-restrictions-field-reference/IC588333.png)) become available only after you click one or more work items listed in the links control tab.
 
-The **Storyboards** links control restricts users to add links only to storyboards or network shared files. With this control, you can add a new link, open a linked item, and delete a link. Also, only the the web portal version displays the **Start Storyboarding** link within the toolbar.
+The **Storyboards** links control restricts users to add links only to storyboards or network shared files. With this control, you can add a new link, open a linked item, and delete a link. Also, only the web portal version displays the **Start Storyboarding** link within the toolbar.
 
 Storyboards links control (the web portal)
 ![](_img/link-controls-restrictions-field-reference/IC589934.png)

--- a/docs/work/work-items/about-work-items.md
+++ b/docs/work/work-items/about-work-items.md
@@ -186,7 +186,7 @@ You can add work items from various clients, such as:
 - From the web portal backlog pages, you can add user stories, backlog items, features, and epics from the [quick add panel](../backlogs/create-your-backlog.md). 
 - From the [Team Explorer add-in to Visual Studio](../../user-guide/work-team-explorer.md), you can add most types of work items from the Work page.  
 - If you work in [Eclipse](https://eclipse.org/home/newcomers.php), you can create work items using [Team Explorer Everywhere](/vsts/java/download-eclipse-plug-in). 
-- From Test Manager or the web portal, you can can [create test cases that automatically link to a user story or product backlog item](../../test/create-test-cases.md).
+- From Test Manager or the web portal, you can [create test cases that automatically link to a user story or product backlog item](../../test/create-test-cases.md).
 - You can create bugs from the web portal, Visual Studio, or when [testing with Microsoft Test Manager](https://msdn.microsoft.com/library/dd286731.aspx).  
 
 For an overview of all clients that connect to your team project, see [Tools and clients that connect to VSTS and TFS](../../user-guide/tools.md). 

--- a/docs/work/work-items/agile-glossary.md
+++ b/docs/work/work-items/agile-glossary.md
@@ -122,7 +122,7 @@ An interactive list of work items that corresponds to a team's project plan or r
 Each product backlog can be customized by a team. Learn more: [Create your backlog](../backlogs/create-your-backlog.md).   
 
 ## Product backlog item
-A type of work item that defines the applications, requirements, and elements that teams plan to create. Product owners typically define and stack rank product backlog items which are defined defined with the Scrum process.  Learn more: [Scrum process work item types and workflow](guidance/scrum-process-workflow.md).   
+A type of work item that defines the applications, requirements, and elements that teams plan to create. Product owners typically define and stack rank product backlog items which are defined with the Scrum process.  Learn more: [Scrum process work item types and workflow](guidance/scrum-process-workflow.md).   
 
 
 

--- a/docs/work/work-items/work-item-form-controls.md
+++ b/docs/work/work-items/work-item-form-controls.md
@@ -43,7 +43,7 @@ As the following image shows, each work item form comes with a number of control
 | ![Attachment tab icon](../backlogs/_img/icon-attachments-tab-wi.png) | Open Attachments tab   |
 | ![full screen icon](../_img/icons/fullscreen_icon.png) / ![exit full screen icon](../_img/icons/exitfullscreen_icon.png)     | Enter or exit full display mode of a section within the form   |
 |![Collapse section icon](../_img/icons/collapse-wi-section.png)/![Expand section icon](../_img/icons/expand-wi-section.png) | Collapse or expand a section within the form   |  
-| ![New linked work icon icon](../_img/icons/new-linked-work-item.png) | Add new work item and link to existing work item (May appear under ![Actions icon](../_img/icons/actions-icon.png) Actions menu)  |  
+| ![New linked work item icon](../_img/icons/new-linked-work-item.png) | Add new work item and link to existing work item (May appear under ![Actions icon](../_img/icons/actions-icon.png) Actions menu)  |  
 | ![Change work item type icon](../_img/icons/change-type-icon.png) | [Change work item type](../backlogs/remove-delete-work-items.md) (Appears under ![Actions icon](../_img/icons/actions-icon.png) Actions menu)  | 
 | ![Change team project icon](../_img/icons/change-team-project-icon.png) | [Move work item to a different team project](../backlogs/remove-delete-work-items.md) (Appears under ![Actions icon](../_img/icons/actions-icon.png) Actions menu)  | 
 | ![Clone icon](../_img/icons/clone-icon.png) | [Copy work item and optionally change work item type](../backlogs/copy-clone-work-items.md#copy-clone) (Appears  under ![Actions icon](../_img/icons/actions-icon.png) Actions menu)  |  

--- a/release-notes/2017/jun-22-team-services.md
+++ b/release-notes/2017/jun-22-team-services.md
@@ -100,7 +100,7 @@ You can view all the tags on your repository on the **Tags** page. If you manage
 You can easily differentiate between a lightweight and an annotated tag here, as annotated tags show the tagger and the creation date alongside the associated commit, while lightweight tags only show the commit information.
 
 ###Delete tags
-There can be times when you want to delete a tag from your remote repo. It could be due to a typo in the tag name, or you you might have tagged the wrong commit. You can easily delete tags from the VSTS UI by clicking the context menu of a tag on the __Tags__ page and selecting __Delete tag__. 
+There can be times when you want to delete a tag from your remote repo. It could be due to a typo in the tag name, or you might have tagged the wrong commit. You can easily delete tags from the VSTS UI by clicking the context menu of a tag on the __Tags__ page and selecting __Delete tag__. 
 
 **Note:** Deleting tags on remote repos should be exercised with caution.
 

--- a/release-notes/2018/mar-05-vsts.md
+++ b/release-notes/2018/mar-05-vsts.md
@@ -113,7 +113,7 @@ By default, the Azure Resource Manager service endpoints that are automatically 
 
 ### Manage entity-specific security
 
-Previously in role based security, when the security access roles were set, they were set for a user or group at hub level for Deployment groups, Variable groups, Agent queues, and Service endpoints. Now you can turn on and off inheritance for a particular entity so you you can configure security just the way you want to.
+Previously in role based security, when the security access roles were set, they were set for a user or group at hub level for Deployment groups, Variable groups, Agent queues, and Service endpoints. Now you can turn on and off inheritance for a particular entity so you can configure security just the way you want to.
 
 > [!div class="mx-imgBorder"]
 ![Security dialog](_img/131_11.png)


### PR DESCRIPTION
Playing around with https://github.com/errata-ai/vale to find duplicate words.
Ran `vale --glob='*.md' .` with the following `.vale`
```
# This goes in a file named either `.vale` or `_vale`.

StylesPath = path/to/some/directory
MinAlertLevel = error # suggestion, warning or error

[*.{md,txt}] # Only Markdown and .txt files
# List of styles to load
BasedOnStyles = vale, Joblint
# Style.Rule = {YES, NO, suggestion, warning, error} to
# enable/disable a rule or change its level.
vale.Editorializing = NO
```
Some false positives for:
- build. EX: "Team Build build definition"
- Iteration

I split the commits out, but if it's too noisy you can cherry-pick what you want