### PR TITLE
Fix img tag for creating a new service bus.

### DIFF
--- a/docs/service-hooks/services/azure-service-bus.md
+++ b/docs/service-hooks/services/azure-service-bus.md
@@ -36,7 +36,7 @@ for mobile platforms including Android, iOS, Windows Phone 8, and Windows Store.
 2. In the Microsoft Azure portal, in the navigation pane select **SERVICE BUS**
 and then create a new namespace. 
 
-   <img alt="Select or create a service bus" src="./_img/azure-service-bus/create-service-bus.jpg")>
+   <img alt="Select or create a service bus" src="./_img/azure-service-bus/create-service-bus.jpg" style="border: 1px solid #CCCCCC" />
 
 3. Enter a name for the namespace and choose a region.
 


### PR DESCRIPTION
The tag had an invalid character in the markup, which caused the markup to render as text in the document.