### PR TITLE
typo: Missing "ref" in tfs/server redirects

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -157,27 +157,27 @@
     },
     {
       "source_path": "docs/tfs-server/command-line/tfsservicecontrol-cmd.md",
-      "redirect_url": "/tfs/server/command-line/tfsservicecontrol-cmd",
+      "redirect_url": "/tfs/server/ref/command-line/tfsservicecontrol-cmd",
       "redirect_document_id": false
     },
     {
       "source_path": "docs/tfs-server/command-line/tfs-labconfig-cmd.md",
-      "redirect_url": "/tfs/server/command-line/tfs-labconfig-cmd",
+      "redirect_url": "/tfs/server/ref/command-line/tfs-labconfig-cmd",
       "redirect_document_id": false
     },
     {
       "source_path": "docs/tfs-server/command-line/tfsdeleteproject-cmd.md",
-      "redirect_url": "/tfs/server/command-line/tfsdeleteproject-cmd",
+      "redirect_url": "/tfs/server/ref/command-line/tfsdeleteproject-cmd",
       "redirect_document_id": false
     },
     {
       "source_path": "docs/tfs-server/command-line/tfssecurity-cmd.md",
-      "redirect_url": "/tfs/server/command-line/tfssecurity-cmd",
+      "redirect_url": "/tfs/server/ref/command-line/tfssecurity-cmd",
       "redirect_document_id": false
     },
     {
       "source_path": "docs/tfs-server/command-line/tfsconfig-cmd.md",
-      "redirect_url": "/tfs/server/command-line/tfsconfig-cmd",
+      "redirect_url": "/tfs/server/ref/command-line/tfsconfig-cmd",
       "redirect_document_id": false
     },
     {


### PR DESCRIPTION
Not sure if it's better to do a redirect on the `tfs-docs` repo, but that appears to be private right now