### PR TITLE
Moved "argument" outside of inline code delimiters

### DIFF
--- a/docs/pipelines/tasks/_shared/msbuild_args.md
+++ b/docs/pipelines/tasks/_shared/msbuild_args.md
@@ -26,7 +26,7 @@ ms.topic: include
 <td>Clean</td>
 <td>
 <p>Set to False if you want to make this an incremental build. This setting might reduce your build time, especially if your codebase is large. This option has no practical effect unless you also set Clean repository to False.</p>
-<p>Set to True if you want to rebuild all the code in the code projects. This is equivalent to the MSBuild ```/target:clean argument```.</p>
+<p>Set to True if you want to rebuild all the code in the code projects. This is equivalent to the MSBuild ```/target:clean``` argument.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Improving clarity; the argument is "/target:clean" not "/target:clean argument" and should be represented as such to avoid confusion and maintain consistent formatting.