### PR TITLE
docs: Reformat for bullet list rendering

### DIFF
--- a/docs/integrate/previous-apis/git/pull-requests/overview.md
+++ b/docs/integrate/previous-apis/git/pull-requests/overview.md
@@ -18,20 +18,15 @@ ms.date: 11/3/2016
 
 Use these APIs to work with a Pull Request in a Team Foundation managed Git repository.
 
-* [General Operations](./pull-requests.md)
-This section describes how to find, examine, edit and complete pull requests.
+* [General Operations](./pull-requests.md) describes how to find, examine, edit and complete pull requests.
 
-* [Comments](./threads.md)
-Users can comment on pull requests.  These comments are grouped into threads which can be used on the pull request in general or about a particular section of a file in the pull request.
+* [Comments threads](./threads.md) can be added to the pull request in general or to a specific location in a file.  These comments are grouped into threads which can be used on the pull request in general or about a particular section of a file in the pull request.
 
-* [Iterations](./iterations.md)
-Iterations contain the history of the pull request.  Every time commits are pushed to the source branch and when the pull request is created, an iteration is created.  Each iteraction can contain more than one commit.
+* [Iterations](./iterations.md) contain the history of the pull request.  Every time commits are pushed to the source branch and when the pull request is created, an iteration is created.  Each iteration can contain more than one commit.
 
-* [Reviewers](./reviewers.md)
-The primary action for reviewers is to vote to approve or reject the pull request.
+* [Reviewers](./reviewers.md) vote to approve or reject the pull request.
 
-* [Work Items](./work-items.md)
-Pull requests can be linked to work items.
+* [Work Items](./work-items.md) can be linked to Pull requests.
 
 [!INCLUDE [ID_vs_Name](../_data/id_or_name.md)]
 


### PR DESCRIPTION
The bullet list doesn't support the multi-line text of the previous version. Pulled text from linked articles.

___
I'm not a tech writer so maybe someone has a better idea of wording for this.