### PR TITLE
Update link of Visual Studio TFS Branching Guide (Fix #1406)

### DIFF
--- a/docs/tfvc/branch-folders-files.md
+++ b/docs/tfvc/branch-folders-files.md
@@ -187,4 +187,4 @@ To perform this procedure, your **Check out** permission and your **Merge** perm
  [Branch Command](branch-command.md)  
  [Branches Command](branches-command.md)  
  [Branch strategically](branch-strategically.md)  
-[Visual Studio TFS Branching Guide](http://go.microsoft.com/fwlink/?LinkId=191400)
+[Visual Studio TFS Branching Guide](https://docs.microsoft.com/en-us/vsts/tfvc/branching-strategies-with-tfvc)


### PR DESCRIPTION
Fix #1406. 
Update link of Visual Studio TFS Branching Guide to the latest docs link. 
The original Codeplex link is dead, and it's also described by VS ALM Rangers team in this blog: https://blogs.msdn.microsoft.com/visualstudioalmrangers/2016/07/18/the-new-branching-guidance-for-team-foundation-server-team-services-and-others/

I believe there are other pages that has the same stale Codeplex links.

cc @steved0x 