### PR TITLE
Added new line underneath version include

### DIFF
--- a/docs/pipelines/release/artifacts.md
+++ b/docs/pipelines/release/artifacts.md
@@ -15,6 +15,7 @@ monikerRange: '>= tfs-2015'
 # Release artifacts and artifact sources
 
 [!INCLUDE [version-rm-dev14](../_shared/version-rm-dev14.md)]
+
 ::: moniker range="<= tfs-2018"
 [!INCLUDE [temp](../_shared/concept-rename-note.md)]
 ::: moniker-end


### PR DESCRIPTION
The rendering is currently broken for supported versions at the top of the page. Added a new line to allow the page to render appropriately.