### PR TITLE
Fix #1518: Update link to Windows commands in batch files

### DIFF
--- a/docs/pipelines/tasks/utility/batch-script.md
+++ b/docs/pipelines/tasks/utility/batch-script.md
@@ -108,7 +108,7 @@ This task is open source [on GitHub](https://github.com/Microsoft/vsts-tasks). F
 
 ### Where can I learn about batch files?
 
-[Using batch files](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands)
+[Using batch files](https://docs.microsoft.com/windows-server/administration/windows-commands/windows-commands)
 
 ### Where can I learn Windows commands?
 

--- a/docs/pipelines/tasks/utility/batch-script.md
+++ b/docs/pipelines/tasks/utility/batch-script.md
@@ -108,7 +108,7 @@ This task is open source [on GitHub](https://github.com/Microsoft/vsts-tasks). F
 
 ### Where can I learn about batch files?
 
-[Using batch files](http://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/batch.mspx?mfr=true)
+[Using batch files](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands)
 
 ### Where can I learn Windows commands?
 


### PR DESCRIPTION
Update link to Windows commands in batch files, because previous link is not available anymore.

I think it's still using the old link, but now the batch files and cmd files are within MS Docs Windows Server sections.

Fix #1518