### PR TITLE
pipelines: Fix vs2017-win2016 image name

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -32,7 +32,7 @@ The Microsoft-hosted agent pool provides 5 virtual machine images to choose from
 | Development tools on Ubuntu | ubuntu-16.04 | Hosted Ubuntu 1604 |
 | Development tools on macOS | xcode9-macos10.13 (see notes below) | Hosted macOS |
 | .NET Core | ubuntu-1604 or win1803 or vs2017-win2016 | Hosted Ubuntu 1604 or Hosted VS2017 or Hosted Windows Container |
-| Visual Studio 2017 | vs2017-win2017 | Hosted VS2017 |
+| Visual Studio 2017 | vs2017-win2016 | Hosted VS2017 |
 | Visual Studio 2015 | vs2015-win2012r2 | Hosted |
 
 # [YAML](#tab/yaml)


### PR DESCRIPTION
Fix vs2017-win2016 image name being incorrect in the table (but correct in the following samples)