### PR TITLE
Remove indention from code block

### DIFF
--- a/docs/extend/develop/add-hub-group.md
+++ b/docs/extend/develop/add-hub-group.md
@@ -22,38 +22,38 @@ then follow these steps to create the hub group.
 
 Here's the complete extension manifest with Hello in the samples hub group.
 
-	```
-	{
-		"namespace": "Fabrikam.myextension",
-		"name": "My Extension",
-		"description": "This is my first extension",
-		"version": "1.0",
-		"provider": {
-			"name": "Fabrikam Fiber Inc"
-		},
-		"baseUri": "https://localhost:port",
-		"icon": "images/logo.png",
-		"links": {
-			"info": "info.html",
-			"support": "support.html",
-			"termsOfService": "terms-of-service.html"
-		},
-		"contributions": {
-			"vss.web#hubGroups.project": [
-				{
-					"id": "samples",
-					"name": "Samples",
-					"order":  30
-				}
-			],
-			"vss.web#hubs": [
-				{
-					"id": "myhub",
-					"name": "Hello",
-					"groupId": "samples",
-					"uri": "hello-world.html"
-				}
-			]
-		}
+```
+{
+	"namespace": "Fabrikam.myextension",
+	"name": "My Extension",
+	"description": "This is my first extension",
+	"version": "1.0",
+	"provider": {
+		"name": "Fabrikam Fiber Inc"
+	},
+	"baseUri": "https://localhost:port",
+	"icon": "images/logo.png",
+	"links": {
+		"info": "info.html",
+		"support": "support.html",
+		"termsOfService": "terms-of-service.html"
+	},
+	"contributions": {
+		"vss.web#hubGroups.project": [
+			{
+				"id": "samples",
+				"name": "Samples",
+				"order":  30
+			}
+		],
+		"vss.web#hubs": [
+			{
+				"id": "myhub",
+				"name": "Hello",
+				"groupId": "samples",
+				"uri": "hello-world.html"
+			}
+		]
 	}
-	```
+}
+```


### PR DESCRIPTION
The code block was indented which meant that the indented content was considered code, but three back ticks were added and indented as well, which resulted in the back ticks being displayed when the page was rendered.

This change removes one level of indentation from the code block so that the back ticks are not displayed when the page is rendered.