### PR TITLE
Clarify exclusion between `parallel` and `matrix`

### DIFF
--- a/docs/pipelines/process/phases.md
+++ b/docs/pipelines/process/phases.md
@@ -76,8 +76,9 @@ jobs:
   timeoutInMinutes: number
   cancelTimeoutInMinutes: number
   strategy:
-    parallel: number
     maxParallel: number
+    # parallel and matrix are mutually exclusive, while maxParallel affects both
+    parallel: number
     matrix: { string: { string: string } }
   pool:
     name: string


### PR DESCRIPTION
Related to #1770