### PR TITLE
Monikor-End displaying on rendered page

### DIFF
--- a/docs/organizations/settings/_shared/open-process-admin-context-ts.md
+++ b/docs/organizations/settings/_shared/open-process-admin-context-ts.md
@@ -24,8 +24,7 @@ You create, manage, and make customizations to processes from **Organization Set
 
 	> [!IMPORTANT]  
 	>If you don't see **Process**, then you're working from an on-premises TFS. The **Process** page isn't supported. You must use the features supported for the On-premises XML process model as described in [Customize your work tracking experience](/azure/devops/reference/customize-work).
-
-::: moniker-end  
+::: moniker-end
 
 # [Previous navigation](#tab/previous-nav)
 


### PR DESCRIPTION
The `::: Monikor-End` tag is displaying on the [rendered page for this](https://docs.microsoft.com/en-us/azure/devops/organizations/settings/work/customize-process?view=vsts&tabs=new-nav)  I'm not what the reason is, but the only difference I see between this page and other pages that do not display `::: moniker-end` is an additional new line between the content and the `::: moniker-end` tag.

This change removes the additional new line.