### PR TITLE
Fixed broken link to code samples

### DIFF
--- a/docs/integrate/previous-apis/git/repositories.md
+++ b/docs/integrate/previous-apis/git/repositories.md
@@ -17,7 +17,7 @@ ms.date: 08/04/2016
 
 [!INCLUDE [GET_STARTED](../_data/get-started.md)]
 
-There are [code samples](https://github.com/Microsoft/vsts-dotnet-samples/blob/master/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/repos/git/RepositoriesSample.cs) available for this endpoint.
+There are [code samples](https://github.com/Microsoft/vsts-dotnet-samples/blob/master/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/Git/RepositoriesSample.cs) available for this endpoint.
 
 
 ## Get a list of repositories


### PR DESCRIPTION
Fixed the broken link to RepositoriesSample.cs (in the repo: Microsoft/vsts-dotnet-samples)