### PR TITLE
Update hosted agents link from vsts-image-generation to azure-pipelines-image-generation

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -77,10 +77,10 @@ You can manually select from tool versions on macOS images. [See below](#mac-pic
 
 Software on Microsoft-hosted agents is updated once each month.
 
-* [Visual Studio 2017 on Windows Server 2016 (Hosted VS2017)](https://github.com/Microsoft/vsts-image-generation/blob/master/images/win/Vs2017-Server2016-Readme.md).
-* [Ubuntu 16.04 (Hosted Ubuntu 1604)](https://github.com/Microsoft/vsts-image-generation/blob/master/images/linux/Ubuntu1604-README.md).
-* [Xcode 8, 9, and 10 on macOS 10.13 (Hosted macOS)](https://github.com/Microsoft/vsts-image-generation/blob/master/images/macos/macos-Readme.md).
-* [Windows Server 1803 (Hosted Windows Container)](https://github.com/Microsoft/vsts-image-generation/blob/master/images/win/WindowsContainer1803-Readme.md)
+* [Visual Studio 2017 on Windows Server 2016 (Hosted VS2017)](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2017-Server2016-Readme.md).
+* [Ubuntu 16.04 (Hosted Ubuntu 1604)](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/linux/Ubuntu1604-README.md).
+* [Xcode 8, 9, and 10 on macOS 10.13 (Hosted macOS)](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-Readme.md).
+* [Windows Server 1803 (Hosted Windows Container)](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/WindowsContainer1803-Readme.md)
 * [Visual Studio 2015 on Windows Server 2012r2 (Hosted)](https://github.com/adventworks/hosted-pool-images/blob/2017.10.02/vs2015-on-windows-2012r2/image.md).
 
 ## Capabilities and limitations


### PR DESCRIPTION
Update hosted agents link from Microsoft/vsts-image-generation to Microsoft/azure-pipelines-image-generation, because the repo name has changed.

cc @elbatk , @steved0x