### PR TITLE
Fix bug for docker login yml code snippet

### DIFF
--- a/docs/pipelines/languages/docker.md
+++ b/docs/pipelines/languages/docker.md
@@ -310,7 +310,7 @@ To push the image to Azure Container Registry, use the following snippet:
 
 ```yaml
 - script: |
-    docker login -u $(dockerId).azurecr.io -p $(pswd) $(dockerId).azurecr.io
+    docker login -u $(dockerId) -p $(pswd) $(dockerId).azurecr.io
     docker push $(dockerId).azurecr.io/$(imageName)
 ```
 


### PR DESCRIPTION
Fix a bug for logging into azure container registry from yaml file.

The username is just the dockerId, not the dockerID with the .azurecr.io added to the end of it, that portion is just for the login server used at the end