### PR TITLE
Fix markdown handling of "features/*" wildcard

### DIFF
--- a/docs/pipelines/release/triggers.md
+++ b/docs/pipelines/release/triggers.md
@@ -46,7 +46,7 @@ You add build branch filters if you want to create the release only
 when the build is produced by compiling code from certain branches
 (only applicable when the code is in a TFVC, Git, or GitHub repository)
 or when the build has certain tags. These can be both include and exclude filters.
-For example, use **features/\*** to include all builds under the **features** branch.
+For example, use **features/*** to include all builds under the **features** branch.
 You can also include [custom variables](variables.md) in a filter value.
 
 Alternatively, you can specify a filter to use the default branch specified


### PR DESCRIPTION
Provided markdown uses an escape for the asterisk in `features/*`, and although this seems to look fine in GitHub preview, it does not render correctly on docs.microsoft.com:

![image](https://user-images.githubusercontent.com/686/46999011-2dd1b980-d0d9-11e8-8ff2-e3f4b7df024c.png)
