### PR TITLE
Add "set-variables-in-scripts" file

### DIFF
--- a/docs/pipelines/build/variables.md
+++ b/docs/pipelines/build/variables.md
@@ -31,6 +31,8 @@ This is the comprehensive list of predefined build variables.
 These variables are automatically set by the system and read-only. (The exceptions are Build.Clean and System.Debug.)
 Learn more about [working with variables](../process/variables.md).
 
+[!INCLUDE [set-variables-in-scripts](../_shared/set-variables-in-scripts.md)]
+
 ## Build.Clean 
 
 ::: moniker range="> tfs-2017"


### PR DESCRIPTION
Now only in the release variables page, there is a tutorial about how to use the variables on Batch/PowerShell/Shell.
It's would be great if it will also available in the Build variables page.