### PR TITLE
Fix typo - misspelling of the word 'subscription' in howto-provision-deployment-group-agents.md

### DIFF
--- a/docs/pipelines/release/deployment-groups/howto-provision-deployment-group-agents.md
+++ b/docs/pipelines/release/deployment-groups/howto-provision-deployment-group-agents.md
@@ -83,7 +83,7 @@ For information about agents and pipelines, see:
 
    ![Installing the Azure Pipelines Agent extension](_img/howto-provision-azure-vm-agents/azure-vm-create.png)
 
-1. In the **Install extension** blade, specify the name of the Azure Pipelines subacription to use. For example, if the URL is `https://dev.azure.com/contoso`, just specify **contoso**.
+1. In the **Install extension** blade, specify the name of the Azure Pipelines subscription to use. For example, if the URL is `https://dev.azure.com/contoso`, just specify **contoso**.
 
 1. Specify the project name and the deployment group name.
    


### PR DESCRIPTION
Fix spelling of 'subscription' in point 4 under 'Install the Azure Pipelines Agent Azure VM extension'

Fixes #2148