### PR TITLE
typo: unnecessary quote

### DIFF
--- a/docs/pipelines/process/variables.md
+++ b/docs/pipelines/process/variables.md
@@ -164,7 +164,7 @@ jobs:
 
 - job: Windows
   pool:
-    vmImage: 'vs2017-win2016''
+    vmImage: 'vs2017-win2016'
   steps:
   - script: echo %AGENT_HOMEDIRECTORY%
   - powershell: Write-Host $env:AGENT_HOMEDIRECTORY


### PR DESCRIPTION
Just what the title says, there is a superfluous quote in the document explaining variables in Azure pipelines.