### PR TITLE
chore: Update StackOverflow tag to "azure-devops"

### DIFF
--- a/release-notes/2018/sprint-142-update.md
+++ b/release-notes/2018/sprint-142-update.md
@@ -260,7 +260,7 @@ We would love to hear what you think about these features. Use the feedback menu
 > [!div class="mx-imgBorder"]
 ![Make a suggestion](../_img/help-make-a-suggestion.png)
 
-You can also get advice and your questions answered by the community on [Stack Overflow](https://stackoverflow.com/questions/tagged/vsts).
+You can also get advice and your questions answered by the community on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-devops).
 
 Thanks,
 


### PR DESCRIPTION
VSTS is redirected to the new tag now