### PR TITLE
fix: Space after brace in markdown links

### DIFF
--- a/docs/articles/migration-troubleshooting.md
+++ b/docs/articles/migration-troubleshooting.md
@@ -36,7 +36,7 @@ The largest table size is currently {Table size}GBs. This is above the recommend
 Similar to the previous warning, this warning means you will have to use the SQL Azure VM method to complete the import. Follow the instructions linked from the warning message to setup the VM and complete your import. This warning does **NOT** mean that your collection is too big to be imported. 
 
 ```cmdline
-The database metadata size is currently {Metadata Size}GBs. This is above the recommended size of {Warning Size}GBs. It's recommended that you consider cleaning up older data as described in [Cleaning up old data] (/tfs/server/upgrade/clean-up-data).
+The database metadata size is currently {Metadata Size}GBs. This is above the recommended size of {Warning Size}GBs. It's recommended that you consider cleaning up older data as described in [Cleaning up old data](/tfs/server/upgrade/clean-up-data).
 ```
 
 This warning means that your database is approaching the limit for total metadata size. Metadata size refers to the size of your database without including files, code, and other binary data. The warning does **NOT** mean that your collection is too big for import, rather its metadata size is larger than the vast majority of other databases. It's strongly recommended that you [reduce the size](/tfs/server/upgrade/clean-up-data) of your database before import. Reducing the size provides the additional benefit of speeding up your import.

--- a/docs/boards/plans/agile-culture.md
+++ b/docs/boards/plans/agile-culture.md
@@ -17,7 +17,7 @@ ms.date: 08/04/2016
 [!INCLUDE [temp](../_shared/version-vsts-tfs-all-versions.md)]
 
 > [!NOTE] 
-> Are you new to Agile? Learn more about [Agile Culture] (/azure/devops/learn/agile/agile-culture) and [Scaling Agile to Large Teams] (/azure/devops/learn/agile/scale-agile-large-teams).
+> Are you new to Agile? Learn more about [Agile Culture](/azure/devops/learn/agile/agile-culture) and [Scaling Agile to Large Teams](/azure/devops/learn/agile/scale-agile-large-teams).
 
 As your team grows, you want your tools to grow with it. And, if you're an enterprise adopting Agile methodologies, you want your Agile tools to support the business objectives of your enterprise.  
 

--- a/docs/boards/queries/query-operators-variables.md
+++ b/docs/boards/queries/query-operators-variables.md
@@ -205,7 +205,7 @@ You can use query operators in the following table to specify how each value in 
 	<td><p> <strong>String</strong> </p></td></tr>
 <tr>
 	<td><p><strong>Contains Words</strong></p></td>
-	<td><p>Contains the exact text string or words within the field you selected for filtering. You can also enter partial words or phrases that contain the wildcard character, <strong></strong>*. For restrictions, see [Full-text searches] (#full-text) for server and collation requirements.</p></td>
+	<td><p>Contains the exact text string or words within the field you selected for filtering. You can also enter partial words or phrases that contain the wildcard character, <strong></strong>*. For restrictions, see [Full-text searches](#full-text) for server and collation requirements.</p></td>
 	<td><p>Long-text fields that are indexed for full-text search, which correspond to all <strong>PlainText</strong> and <strong>HTML</strong> fields and <strong>Title</strong>.</p></td></tr>
 <tr>
 	<td><p><strong>Does Not Contain Words</strong></p></td>

--- a/docs/extend/develop/add-action.md
+++ b/docs/extend/develop/add-action.md
@@ -51,7 +51,7 @@ Below is the code snippet that adds your action to the contributions section of 
 | text               | Text that will appear on the menu item.                                                                         |                  
 | title              | Tooltip text that will appear on the menu item.                                                                 |                   
 | icon               | URL to an icon that will appear on the menu item. Relative URLs are resolved using baseUri.                     |                   
-| groupId            | Determines where this menu item will appear in relation to the others. [How to discover menu group identifiers] (../test/discover-menu-group-ids.md). |
+| groupId            | Determines where this menu item will appear in relation to the others. [How to discover menu group identifiers](../test/discover-menu-group-ids.md). |
 | uri                | URI to a page that registers the menu action handler (see below).                                               |                   
 | registeredObjectId | (Optional) Name of the registered menu action handler. Defaults to the contributor id.                          |                   
 

--- a/docs/integrate/previous-apis/wit/samples.md
+++ b/docs/integrate/previous-apis/wit/samples.md
@@ -274,7 +274,7 @@ If you already have the query id, you can skip step 1. The code sample below sho
 ## Query Work Items with WIQL
 <a name="queryworkitemswithwiql" />
 
-If you don't know the query you want to execute, you can use the [work item query language (WIQL)] (https://msdn.microsoft.com/library/bb130306.aspx) to dynamically create a query in your code.
+If you don't know the query you want to execute, you can use the [work item query language (WIQL)](https://msdn.microsoft.com/library/bb130306.aspx) to dynamically create a query in your code.
 
 >[!div class="tabbedCodeSnippets" cs='C#' cl='.NET Client Library']
 >```cs

--- a/docs/pipelines/test/review-code-coverage-results.md
+++ b/docs/pipelines/test/review-code-coverage-results.md
@@ -75,7 +75,7 @@ The code coverage artifacts published during the build can be viewed under the
 ## Tasks
 
 * [Publish Code Coverage Results](../tasks/test/publish-code-coverage-results.md) publishes code coverage results to Azure Pipelines or TFS,
-  which were produced by a build in [Cobertura] (http://cobertura.github.io/cobertura/) or [JaCoCo](http://www.eclemma.org/jacoco/) format. 
+  which were produced by a build in [Cobertura](http://cobertura.github.io/cobertura/) or [JaCoCo](http://www.eclemma.org/jacoco/) format. 
 * Built-in tasks such as [Visual Studio Test](../tasks/test/vstest.md),
   [.NET Core](../tasks/build/dotnet-core.md), [Ant](../tasks/build/ant.md), [Maven](../tasks/build/maven.md),
   [Gulp](../tasks/build/gulp.md), [Grunt](../tasks/build/grunt.md), and [Gradle](../tasks/build/gradle.md)

--- a/docs/report/extend-analytics/odata-supported-features.md
+++ b/docs/report/extend-analytics/odata-supported-features.md
@@ -61,7 +61,7 @@ For more details, see [Aggregate data](aggregated-data-analytics.md)
 ## Supported functions
 | Canonical function | Description |
 | ------------------ | ----------- |  
-| [```cast```] (http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc371341801) |  Returns expression casted to specified type  |  
+| [```cast```](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc371341801) |  Returns expression casted to specified type  |  
 | [```contains```](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc444868695) |  Returns true if the second parameter string value is a substring of the first parameter string value, otherwise it returns false  |  
 | [```endswith```](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc371341774) | Returns true if the first parameter string value ends with the second parameter string value, otherwise it returns false |  
 | [```startswith```](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc444868699) |  Returns true if the first parameter string value starts with the second parameter string value, otherwise it returns false |  


### PR DESCRIPTION
Not sure if DocFx is more tolerant to the space, but GitHub won't render these as links