### PR TITLE
Fixed examples of script and powershell tasks.

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -564,9 +564,11 @@ It will run a script using cmd.exe on Windows and Bash on other platforms.
 # [Example](#tab/example)
 
 ```yaml
-- powershell: |
-    Write-Host "Hello $env:name"
-  displayName: A multiline PowerShell script
+- script: echo Hello $(name)
+  displayName: Say hello
+  name: firstStep
+  workingDirectory: $(Build.SourcesDirectory)
+  failOnStderr: true
   env:
     name: Microsoft
 ```
@@ -637,11 +639,9 @@ It will run a script in PowerShell on Windows.
 # [Example](#tab/example)
 
 ```yaml
-- script: echo Hello $(name)
-  displayName: Say hello
-  name: firstStep
-  workingDirectory: $(Build.SourcesDirectory)
-  failOnStderr: true
+- powershell: |
+    Write-Host "Hello $env:name"
+  displayName: A multiline PowerShell script
   env:
     name: Microsoft
 ```


### PR DESCRIPTION
The original order of the two examples are wrong, so change them to match the actual section order.