### PR TITLE
Fix typo: synomymous -> synonymous

### DIFF
--- a/docs/pipelines/build/_shared/variables-tfs2015.md
+++ b/docs/pipelines/build/_shared/variables-tfs2015.md
@@ -177,7 +177,7 @@ This variable is agent-scoped. It can be used as an environment variable in a sc
 <td>Build.Repository.LocalPath</td>
 <td>
 [!INCLUDE [include](../_shared/variables-build-sources-directory.md)]
-<p>This variable is synomymous with Build.SourcesDirectory.</p>
+<p>This variable is synonymous with Build.SourcesDirectory.</p>
 </td>
 </tr>
 
@@ -266,7 +266,7 @@ Note: In TFVC, if you are running a gated check-in build or manually building a 
 <td>Build.SourcesDirectory</td>
 <td>
 [!INCLUDE [include](../_shared/variables-build-sources-directory.md)]
-<p>This variable is synomymous with Build.Repository.LocalPath.</p>
+<p>This variable is synonymous with Build.Repository.LocalPath.</p>
 </td>
 </tr>
 

--- a/docs/pipelines/build/_shared/variables-tfs2017.md
+++ b/docs/pipelines/build/_shared/variables-tfs2017.md
@@ -166,7 +166,7 @@ This variable is agent-scoped. It can be used as an environment variable in a sc
 <td>Build.Repository.LocalPath</td>
 <td>
 [!INCLUDE [include](../_shared/variables-build-sources-directory.md)]
-<p>This variable is synomymous with Build.SourcesDirectory.</p>
+<p>This variable is synonymous with Build.SourcesDirectory.</p>
 </td>
 </tr>
 
@@ -260,7 +260,7 @@ Note: In TFVC, if you are running a gated check-in build or manually building a 
 <td>Build.SourcesDirectory</td>
 <td>
 [!INCLUDE [include](../_shared/variables-build-sources-directory.md)]
-<p>This variable is synomymous with Build.Repository.LocalPath.</p>
+<p>This variable is synonymous with Build.Repository.LocalPath.</p>
 </td>
 </tr>
 

--- a/docs/pipelines/build/_shared/variables-tfs2018.md
+++ b/docs/pipelines/build/_shared/variables-tfs2018.md
@@ -176,7 +176,7 @@ This variable is agent-scoped. It can be used as an environment variable in a sc
 <td>Build.Repository.LocalPath</td>
 <td>
 [!INCLUDE [include](../_shared/variables-build-sources-directory.md)]
-<p>This variable is synomymous with Build.SourcesDirectory.</p>
+<p>This variable is synonymous with Build.SourcesDirectory.</p>
 </td>
 </tr>
 
@@ -270,7 +270,7 @@ Note: In TFVC, if you are running a gated check-in build or manually building a 
 <td>Build.SourcesDirectory</td>
 <td>
 [!INCLUDE [include](../_shared/variables-build-sources-directory.md)]
-<p>This variable is synomymous with Build.Repository.LocalPath.</p>
+<p>This variable is synonymous with Build.Repository.LocalPath.</p>
 </td>
 </tr>
 

--- a/docs/pipelines/build/_shared/variables-vsts.md
+++ b/docs/pipelines/build/_shared/variables-vsts.md
@@ -190,7 +190,7 @@ This variable is agent-scoped. It can be used as an environment variable in a sc
 <td>Build.Repository.LocalPath</td>
 <td>
 [!INCLUDE [include](../_shared/variables-build-sources-directory.md)]
-<p>This variable is synomymous with Build.SourcesDirectory.</p>
+<p>This variable is synonymous with Build.SourcesDirectory.</p>
 </td>
 </tr>
 
@@ -285,7 +285,7 @@ Note: In TFVC, if you are running a gated check-in build or manually building a 
 <td>Build.SourcesDirectory</td>
 <td>
 [!INCLUDE [include](../_shared/variables-build-sources-directory.md)]
-<p>This variable is synomymous with Build.Repository.LocalPath.</p>
+<p>This variable is synonymous with Build.Repository.LocalPath.</p>
 </td>
 </tr>
 


### PR DESCRIPTION
Found a small typo while I was looking for the variable to get the source checkout directory. 