### PR TITLE
fix: cmd for macOS, use echo -n for PAT base64 token

### DIFF
--- a/docs/artifacts/_shared/npm/npmrc.md
+++ b/docs/artifacts/_shared/npm/npmrc.md
@@ -52,7 +52,7 @@ The _Connect to feed_ dialog will generate an appropriately-formatted token that
 
     # [Mac](#tab/mac)
     ```
-    base64 <<< "YOUR_PAT_GOES_HERE"
+    echo -n "YOUR_PAT_GOES_HERE" | base64
     ```
    ---
 

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -93,7 +93,7 @@ Versions in the “Server” column are linked to the appropriate download locat
     </thead>
     <tbody>
         <tr>
-            <td rowspan="12">[04 December 2018](2018/sprint-144-update.md)</td>
+            <td rowspan="12">[04 December 2018](2018/sprint-143-update.md)</td>
             <td>Link GitHub commits and pull requests to Azure Boards work items</td><td>Future</td>
         </tr>
         <tr><td>Acquire Azure Boards as a service</td><td>Future</td></tr>


### PR DESCRIPTION
Fix wrong command on macOS/linux to generate the PAT base64 token.

Close #2612