### PR TITLE
Changed Stackoverflow's URL

### DIFF
--- a/docs/test/_shared/help-and-support-footer.md
+++ b/docs/test/_shared/help-and-support-footer.md
@@ -5,5 +5,5 @@ ms.topic: include
 ## Help and support
 
 Report any problems on [Developer Community](https://developercommunity.visualstudio.com/),
-get advice on [Stack Overflow](https://stackoverflow.com/questions/tagged/vs-team-services),
+get advice on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-devops),
 and get support via our [Support](https://azure.microsoft.com/support/devops/) page.


### PR DESCRIPTION
After VSTS is changed to Azure DevOps, Stackoverflow has changed the tag name into `azure-devops`. I think we need to update this change.

This PR is a re-open one after syncing fixes (previously opened in #2640)