### PR TITLE
Added a new artifact variable

### DIFF
--- a/docs/pipelines/release/variables.md
+++ b/docs/pipelines/release/variables.md
@@ -164,6 +164,7 @@ To view the full list, see [View the current values of all variables](#view-vars
 > | Release.ReleaseWebURL | The URL for this release. | https:&#47;/dev.azure.com/fabrikam/f3325c6c/\_release?releaseId=392&_a=release-summary |
 > | Release.SkipArtifactDownload | Boolean value that specifies whether or not to skip downloading of artifacts to the agent. | FALSE |
 > | Release.TriggeringArtifact.Alias | The alias of the artifact which triggered the release. This is empty when the release was scheduled or triggered manually. | fabrikam\_app |
+> | Release.PrimaryArtifactSourceAlias | The alias of the primary artifact source | fabrikam\_web |
 
 <!-- Other hidden variables
 [RELEASE_RELEASEWEBURL] -> [https://dev.azure.com/adventwrks/79f5c12e-3337-4151-be41-a268d2c73344/_apps/hub/ms.vss-releaseManagement-web.hub-explorer?releaseId=118&_a=release-summary]


### PR DESCRIPTION
Based on the customer feedback, we have introduced a new artifact variable to extract the alias for primary artifact source as a variable. https://developercommunity.visualstudio.com/content/problem/255744/release-definition-artifact-source-alias-not-avail.html