### PR TITLE
Groupnames wrong!

### DIFF
--- a/docs/pipelines/library/service-endpoints.md
+++ b/docs/pipelines/library/service-endpoints.md
@@ -70,7 +70,7 @@ You can control who can define new service connections in a library, and who can
 | User | Members of this role can use the service connection when authoring build or release pipelines. |
 | Administrator | In addition to using the service connection, members of this role can manage membership of all other roles for the service connection. The user that created the service connection is automatically added to the Administrator role for that service connection.
 
-Two special groups called **Service connection administrators** and **Service connection creators** are added to every project.
+Two special groups called **Endpoint Administrators** and **Endpoint Creators** are added to every project.
 Members of the Service connection administrators group can manage all service connections. By default, project administrators are added as members of this group. This group is also added as an administrator to every service connection created.
 Members of the Service connection creators group can create new service connections. By default, project contributors are added as members of this group.
 


### PR DESCRIPTION
Think the name of the groups are "Endpoint Administrators" and "Endpoint Creators" instead of "Service connection administrators" and "Service connection creators".