### PR TITLE
Support team link 404s

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -124,9 +124,9 @@ In some setups, you may need to know the range of IP addresses where agents are 
 > We recommend that you check back frequently to ensure you keep an up-to-date list.
 > If agent jobs begin to fail, a key first troubleshooting step is to make sure your configuration matches the latest list of IP addresses.
 
-We publish a [weekly XML file](https://www.microsoft.com/download/confirmation.aspx?id=41653) listing IP ranges for Azure datacenters, broken out by region. This file is published every Wednesday (US Pacific time) with new planned IP ranges. The new IP ranges become effective the following Monday. Hosted agents run in the same region as your Azure DevOps organization. You can check your region by navigating to `https://dev.azure.com/<your_organization>/_settings/overview`. Under **Organization information**, you will see a field indicating your region.
+We publish a [weekly XML file](https://www.microsoft.com/download/confirmation.aspx?id=41653) listing IP ranges for Azure datacenters, broken out by region. This file is published every Wednesday (US Pacific time) with new planned IP ranges. The new IP ranges become effective the following Monday. Hosted agents run in the same region as your Azure DevOps organization. You can check your region by navigating to `https://dev.azure.com/<your_organization>/_settings/organizationOverview`. Under **Overview**, you will see a field indicating your region.
 
-*This information is maintained by the [Azure DevOps support team](https://azure.microsoft.com/support/devops/ip-addresses-used-hosted-build/).*
+*This information is maintained by the [Azure DevOps support team](https://visualstudio.microsoft.com/team-services/support/ip-addresses-used-hosted-build/).*
 
 ## Q & A
 <!-- BEGINSECTION class="md-qanda" -->


### PR DESCRIPTION
This may want changing again (URL references VisualStudio rather than Azure Devops) but the old link wasn't working