### PR TITLE
fix: Remove shorttitle frontmatter

### DIFF
--- a/docs/pipelines/apps/windows/dot-net.md
+++ b/docs/pipelines/apps/windows/dot-net.md
@@ -1,6 +1,5 @@
 ---
 title: Build your .NET desktop app for Windows
-shorttitle: Visual Studio solution
 ms.custom: seodec18
 description: Learn how you can define a continuous integration (CI) pipeline that builds your .NET app on Team Foundation Server and Azure Pipelines.
 ms.prod: devops


### PR DESCRIPTION
That frontmatter doesn't appear to be used in any other articles