### PR TITLE
Correct 'twine upload' command in Python package publishing docs

### DIFF
--- a/docs/pipelines/artifacts/pypi.md
+++ b/docs/pipelines/artifacts/pypi.md
@@ -100,7 +100,7 @@ After you've set up authentication with the preceding snippet, you can use `twin
 # [YAML](#tab/yaml)
 
 ```yaml
-- script: 'twine -r {feedName/EndpointName} --config-file $(PYPIRC_PATH) {package path to publish}'
+- script: 'twine upload -r {feedName/EndpointName} --config-file $(PYPIRC_PATH) {package path to publish}'
 ```
 
 Check out the [script YAML task reference](../yaml-schema.md#script) for the schema for this command.


### PR DESCRIPTION
Previously, running the command produced

```
usage: twine [-h] [--version] {check,register,upload}
twine: error: argument command: invalid choice: 'test-pypi' (choose from 'check', 'register', 'upload')
```