### PR TITLE
Added categories and updated VSS SDK paths

### DIFF
--- a/docs/extend/develop/add-dashboard-widget.md
+++ b/docs/extend/develop/add-dashboard-widget.md
@@ -181,6 +181,9 @@ Create a json file (`vss-extension.json`, for example) in the `home` directory w
 		"name": "My First Set of Widgets",
 		"description": "Samples containing different widgets extending dashboards",
 		"publisher": "fabrikam",
+		"categories": [
+        		"Azure Boards"
+		],
 		"targets": [
 			{
 				"id": "Microsoft.VisualStudio.Services"
@@ -217,7 +220,7 @@ Create a json file (`vss-extension.json`, for example) in the `home` directory w
                 "path": "hello-world.html", "addressable": true
             },
             {
-                "path": "sdk/scripts", "addressable": true
+                "path": "node_modules/vss-web-extension-sdk/lib", "addressable": true, "packagePath": "sdk/scripts"
             },
             {
                 "path": "img", "addressable": true


### PR DESCRIPTION
Categories is required in the manifest and without it you won't be able to upload the VSIX. Updated the VSS SDK file paths so the files will be dropped into the correct folder (according to the HTML) when the extension is created.