### PR TITLE
Fix displayName in docker login bash block

### DIFF
--- a/docs/pipelines/tasks/build/docker.md
+++ b/docs/pipelines/tasks/build/docker.md
@@ -111,8 +111,8 @@ For example, You can use the Docker task to sign into ACR and then use a subsequ
    # Write your commands here
    # Use the environment variables input below to pass secret variables to this script
    docker build -t contoso.azurecr.io/repositoryname:$(Build.BuildId) . # include other options to meet your needs
-   docker push contoso.azurecr.io/repositoryname:$(Build.BuildId) 
-   displayName: 'Build, tag and push image'
+   docker push contoso.azurecr.io/repositoryname:$(Build.BuildId)
+  displayName: 'Build, tag and push image'
 ```
 
 ### Run Docker images


### PR DESCRIPTION
The displayName key needs to be at the same level as the bash key,
otherwise it is considered part of the command to execute.