### PR TITLE
Added note on support for SPN with cert

### DIFF
--- a/docs/pipelines/targets/azure-stack.md
+++ b/docs/pipelines/targets/azure-stack.md
@@ -21,7 +21,7 @@ monikerRange: '> tfs-2018'
 is an extension of Azure that enables the agility and fast-paced innovation of cloud computing
 through a hybrid cloud and on-premises environment.
 
->In addition to supporting Azure AD, Azure DevOps Server 2019 can be used to deploy to Azure stack with [Active Directory Federation Services](/azure/azure-stack/azure-stack-create-service-principals#create-service-principal-for-ad-fs) (AD FS) using [service principal with certificate](https://docs.microsoft.com/en-us/tfs/release-notes/azuredevops2019#create-azure-service-connection-with-service-principal-that-authenticates-with-a-certificate)
+> In addition to supporting Azure AD, Azure DevOps Server 2019 can be used to deploy to Azure stack with [Active Directory Federation Services](/azure/azure-stack/azure-stack-create-service-principals#create-service-principal-for-ad-fs) (AD FS) using a [service principal with certificate](https://docs.microsoft.com/en-us/tfs/release-notes/azuredevops2019#create-azure-service-connection-with-service-principal-that-authenticates-with-a-certificate).
 
 To enable connection to an Azure Stack, you specify it as the **Environment** parameter when you create an
 [Azure Resource Manager service connection](../library/connect-to-azure.md).

--- a/docs/pipelines/targets/azure-stack.md
+++ b/docs/pipelines/targets/azure-stack.md
@@ -21,10 +21,7 @@ monikerRange: '> tfs-2018'
 is an extension of Azure that enables the agility and fast-paced innovation of cloud computing
 through a hybrid cloud and on-premises environment.
 
->At present, Team Foundation Server can be used to deploy to Azure Stack with Azure AD and cannot be used to deploy to
-an [Azure Stack with Azure Directory Federated Services (AD FS)](/azure/azure-stack/azure-stack-identity-overview). Azure Stack with AD FS requires
-a [service principal with certificate](/azure/azure-stack/azure-stack-create-service-principals#create-service-principal-for-ad-fs),
-which is not currently supported in Azure Pipelines/TFS.
+>In addition to supporting Azure AD, Azure DevOps Server 2019 can be used to deploy to Azure stack with [Active Directory Federation Services](/azure/azure-stack/azure-stack-create-service-principals#create-service-principal-for-ad-fs) (AD FS) using [service principal with certificate](https://docs.microsoft.com/en-us/tfs/release-notes/azuredevops2019#create-azure-service-connection-with-service-principal-that-authenticates-with-a-certificate)
 
 To enable connection to an Azure Stack, you specify it as the **Environment** parameter when you create an
 [Azure Resource Manager service connection](../library/connect-to-azure.md).


### PR DESCRIPTION
Starting Azure DevOps Server 2019, we support Service Principal with Certificate auth. With this, customers can use Azure Stack with AD FS. Previously we supported SPN with Key that limited the user with Azure Stack and Azure AD only. 