### PR TITLE
Update docs for Hosted macOS with guide how to change Xcode version for Xamarin

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -160,6 +160,11 @@ The Microsoft-hosted XAML build controller is no longer supported. If you have a
 
   Note that this command does not select the Mono version beyond the Xamarin SDK. To manually select a Mono version, see instructions below.
 
+  In case you are using a non-standard version of Xcode for building your Xamarin.iOS or Xamarin.Mac apps, you should additionally execute this command line:
+
+  `/bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${xcodeRoot};sudo xcode-select --switch ${xcodeRoot}/Contents/Developer" 
+  where ${xcodeRoot} = /Applications/Xcode_10.1.app`
+
 #### Xcode
 
   If you use the [Xcode task](../tasks/build/xcode.md) included with Azure Pipelines and TFS, you can select a version of Xcode in that task's properties. Otherwise, to manually set the Xcode version to use on the **Hosted macOS** agent pool, before your `xcodebuild` build task, execute this command line as part of your build, replacing the Xcode version number 8.3.3 as needed:
@@ -167,6 +172,8 @@ The Microsoft-hosted XAML build controller is no longer supported. If you have a
   `/bin/bash -c "sudo xcode-select -s /Applications/Xcode_8.3.3.app/Contents/Developer"`
 
   Xcode versions on the **Hosted macOS** agent pool can be found [here](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-Readme.md#xcode).
+
+  Note that this command does not works in case of Xamarin app. To manually select a Xcode version for building Xamarin apps, see instructions above.
 
 #### Mono
 

--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -162,8 +162,11 @@ The Microsoft-hosted XAML build controller is no longer supported. If you have a
 
   In case you are using a non-standard version of Xcode for building your Xamarin.iOS or Xamarin.Mac apps, you should additionally execute this command line:
 
-  `/bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${xcodeRoot};sudo xcode-select --switch ${xcodeRoot}/Contents/Developer" 
-  where ${xcodeRoot} = /Applications/Xcode_10.1.app`
+  `/bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${xcodeRoot};sudo xcode-select --switch ${xcodeRoot}/Contents/Developer"`
+  
+  where `${xcodeRoot}` = `/Applications/Xcode_10.1.app`
+
+  Xcode versions on the **Hosted macOS** agent pool can be found [here](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-Readme.md#xcode).
 
 #### Xcode
 


### PR DESCRIPTION
The following page was updated: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=vsts&tabs=designer#xamarin

The old approach to change Xcode works correctly only for native iOS/native macOS apps.
The correct approach for Xamarin apps was added:
`/bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${xcodeRoot};sudo xcode-select --switch ${xcodeRoot}/Contents/Developer"
where ${xcodeRoot} = /Applications/Xcode_10.1.app`