### PR TITLE
Fix "create a backlog" broken link

### DIFF
--- a/docs/boards/_shared/create-team-project-links.md
+++ b/docs/boards/_shared/create-team-project-links.md
@@ -8,7 +8,7 @@ Before you start tracking work, you must have a project. To create one, see [Cre
 If you have a project, start tracking work:  
 
 -   [Add work items to manage a project](/azure/devops/boards/backlogs/add-work-items) - to gain more familiarity with the work item form features  
--   [Create a backlog](/azure/devops/boards/create-your-backlog) - to develop your product backlog   
+-   [Create a backlog](/azure/devops/boards/backlogs/create-your-backlog) - to develop your product backlog   
 -   [Plan a sprint](/azure/devops/boards/sprints/assign-work-sprint) - to start working in Scrum    
 -   [Kanban](/azure/devops/boards/boards/kanban-basics)  - to start working in Kanban  
 -   [Excel](/azure/devops/boards/backlogs/office/bulk-add-modify-work-items-excel) or [Project](/azure/devops/boards/backlogs/office/create-your-backlog-tasks-using-project) - to create a work breakdown structure   


### PR DESCRIPTION
Resolves an issue where the link to *Create a backlog* was 404'ing.