### PR TITLE
use-ssh-keys-to-authenticate.md: list actual hosted fingerprints

### DIFF
--- a/docs/repos/git/use-ssh-keys-to-authenticate.md
+++ b/docs/repos/git/use-ssh-keys-to-authenticate.md
@@ -134,7 +134,15 @@ user interface. Select **Security** in the menu that appears.
    git clone git@ssh.dev.azure.com:v3/fabrikam-fiber/FabrikamFiber/FabrikamFiber
    ```
 
-SSH will ask you to verify that the SSH fingerprint for the server you are connecting to. You should verify that the shown fingerprint matches the fingerprint on the **SSH public keys**  page.
+SSH may display the server's SSH fingerprint and ask you to verify it.
+
+For cloud-hosted Azure DevOps Services, where clone URLs contain either `ssh.dev.azure.com` or `vs-ssh.visualstudio.com`, the fingerprint should match one of the following:
+* MD5: `97:70:33:82:fd:29:3a:73:39:af:6a:07:ad:f8:80:49` (RSA)
+* SHA256: `SHA256:ohD8VZEXGWo6Ez8GSEJQ9WpafgLFsOfLOtGGQCQo6Og` (RSA)
+These fingerprints are also listed in the **SSH public keys** page.
+
+For self-hosted instances of Azure DevOps Server, you should verify that the displayed fingerprint matches one of the fingerprints in the **SSH public keys** page.
+
 SSH displays this fingerprint when it connects to an unknown host to protect you from [man-in-the-middle attacks](https://technet.microsoft.com/library/cc959354.aspx).
 Once you accept the host's fingerprint, SSH will not prompt you again unless the fingerprint changes. 
 


### PR DESCRIPTION
Officially document the fingerprints for the SSH host key used across all of hosted Azure DevOps.

Currently the fingerprints were only visible after signing in to a specific organization.

@sarath-p requested public documentation that can be referenced from non-organization specific projects, e.g. https://github.com/weaveworks/flux/blob/master/docker/verify_known_hosts.sh