### PR TITLE
Clarify that Agent.WorkFolder may not be writable

### DIFF
--- a/docs/pipelines/build/_shared/variables-server2019.md
+++ b/docs/pipelines/build/_shared/variables-server2019.md
@@ -100,6 +100,8 @@ Learn about [managing this directory on a self-hosted agent](https://go.microsof
 <td>
 The working directory for this agent.
 For example: `c:\agent\_work`.
+<br><br>
+This directory is not guaranteed to be writable by pipeline tasks (eg. when mapped into a container)</td>
 </td>
 </tr>
 

--- a/docs/pipelines/build/_shared/variables-vsts.md
+++ b/docs/pipelines/build/_shared/variables-vsts.md
@@ -100,6 +100,8 @@ Learn about [managing this directory on a self-hosted agent](https://go.microsof
 <td>
 The working directory for this agent.
 For example: `c:\agent\_work`.
+<br><br>
+Note: This directory is not guaranteed to be writable by pipeline tasks (eg. when mapped into a container)
 </td>
 </tr>
 


### PR DESCRIPTION
- Especially true when folder is mapped into a container

As mentioned by @TingluoHuang in https://github.com/Microsoft/azure-pipelines-agent/issues/2122#issuecomment-467024271