### PR TITLE
Correcting CMake task arguments

### DIFF
--- a/docs/pipelines/tasks/build/cmake.md
+++ b/docs/pipelines/tasks/build/cmake.md
@@ -48,7 +48,7 @@ cmake
 </td>
 </tr>
 <tr>
-<td>Arguments</td>
+<td>cmakeArgs</td>
 <td>
 Arguments that you want to pass to CMake.
 </td>


### PR DESCRIPTION
'Arguments' is not properly recognized by the task.