### PR TITLE
Remove confusion with configuration shortcut

### DIFF
--- a/docs/pipelines/tasks/_shared/yaml/DotNetCoreCLIV2.md
+++ b/docs/pipelines/tasks/_shared/yaml/DotNetCoreCLIV2.md
@@ -25,7 +25,7 @@
     #publishPackageMetadata: true # Optional
     #publishFeedCredentials: # Required when command == Push && NuGetFeedType == External
     #packagesToPack: '**/*.csproj' # Required when command == Pack
-    #configuration: '$(BuildConfiguration)' # Optional
+    #configurationToPack: '$(BuildConfiguration)' # Optional
     #packDirectory: '$(Build.ArtifactStagingDirectory)' # Optional
     #nobuild: false # Optional
     #versioningScheme: 'off' # Options: off, byPrereleaseNumber, byEnvVar, byBuildNumber


### PR DESCRIPTION
In response to issue #2053 the confusion is coming from configuration being a shortcut for configurationToPack. This item is only used with the pack command, but build and test commands take the configuration as an argument and ignore this configuration item.

https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/DotNetCoreCLIV2