### PR TITLE
Addressing YAML Typo from #3513

### DIFF
--- a/docs/pipelines/build/triggers.md
+++ b/docs/pipelines/build/triggers.md
@@ -110,8 +110,7 @@ If you don't specify any tag triggers, the default is as if you wrote:
 ```yaml
 trigger:
   tags:
-    include:
-    - *
+    include: ['*']
 ```
 
 ::: moniker-end


### PR DESCRIPTION
The YAML in the example should be changed to `'[*]'` as noticed in issue #3513.