### PR TITLE
Correct link to Subscriptions API

### DIFF
--- a/docs/integrate/concepts/service-hooks.md
+++ b/docs/integrate/concepts/service-hooks.md
@@ -13,7 +13,7 @@ ms.date: 08/04/2016
 ---
 
 # Service hooks in Azure DevOps Services
-Using the [Subscriptions](https://docs.microsoft.com/rest/api/vsts/hooks/subscriptions?view=vsts-rest-4.1) REST APIs, you can programmatically create a subscription that performs an action on an external (consumer) service when a specific event occurs in a project. For example, you can create a subscription to notify your service when a build fails.
+Using the [Subscriptions](https://docs.microsoft.com/rest/api/vsts/hooks/subscriptions?view=azure-devops-rest-5.0) REST APIs, you can programmatically create a subscription that performs an action on an external (consumer) service when a specific event occurs in a project. For example, you can create a subscription to notify your service when a build fails.
 
 Supported events:
 - build completed


### PR DESCRIPTION
The old link was pointing to the 4.1 version which apparently doesn't actually support the Subscriptions API. If you clicked on that link, you were automatically redirected to the 5.0 page (with a message "The requested page is not available for vsts-rest-4.1. You have been redirected to the newest product version this page is available for.")