### PR TITLE
Removing redundant section about required permissions

### DIFF
--- a/docs/repos/tfvc/add-check-policies.md
+++ b/docs/repos/tfvc/add-check-policies.md
@@ -26,10 +26,6 @@ Administrators of Team Foundation version control can add check-in policy requir
 
 -   **Work Items**   Requires that one or more work items be associated with the check-in.
 
-**Required Permissions**
-
-To complete this procedure, you must have the **Edit project-level information** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
-
 > Visual Studio 2017 : Check-in policies in Visual Studio 2017 must be set through Team Explorer, tf.exe, or [through registry keys declared in the pkgdef of a Visual Studio extension](/visualstudio/extensibility/internals/createpkgdef-utility). Policies only apply to a single installation of Visual Studio 2017 on your computer. If you have multiple installations of Visual Studio 2017, you'll need to set the check-in policy on each installation. [Learn more](/visualstudio/extensibility/what-s-new-in-the-visual-studio-2017-sdk)
 
 


### PR DESCRIPTION
Fixing doc bug: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1438852/