### PR TITLE
Update clean documentation to be accurate

### DIFF
--- a/docs/pipelines/repos/pipeline-options-for-git.md
+++ b/docs/pipelines/repos/pipeline-options-for-git.md
@@ -83,7 +83,7 @@ Select one of the following options:
 
 * **Sources**: The build pipeline performs an undo of any changes in `$(Build.SourcesDirectory)`. More specifically, the following Git commands are executed prior to fetching the source.
  ```
- git clean -fdx
+ git clean -ffdx
  git reset --hard HEAD
  ```
 


### PR DESCRIPTION
The git clean arguments are git clean -ffdx not git clean -fdx

![image](https://user-images.githubusercontent.com/1538370/54454203-2bba6800-4716-11e9-8756-aec1ed1abb90.png)
