### PR TITLE
Update github.md

### DIFF
--- a/docs/pipelines/repos/github.md
+++ b/docs/pipelines/repos/github.md
@@ -135,7 +135,10 @@ There are 3 authentication types for granting Azure Pipelines access to your Git
 
 ## Integrate using the GitHub App
 
-By installing it in your GitHub account or organization, your pipeline can run without using your personal GitHub identity. Builds and GitHub status updates will be performed using the Azure Pipelines identity. The app works with [GitHub Checks](https://developer.github.com/v3/checks/) to display build, test, and code coverage results in GitHub.
+>[!NOTE]
+>The Azure Pipelines GitHub App is the **recommended** authentication type for continuous integration pipelines. For release pipelines that are triggered by changes to a GitHub repository, use [OAuth](#integrate-using-oauth) or [personal access token](#integrate-using-a-personal-access-token-pat) authentication.
+
+By installing the GitHub App in your GitHub account or organization, your pipeline can run without using your personal GitHub identity. Builds and GitHub status updates will be performed using the Azure Pipelines identity. The app works with [GitHub Checks](https://developer.github.com/v3/checks/) to display build, test, and code coverage results in GitHub.
 
 ### Install the GitHub App
 

--- a/docs/pipelines/repos/github.md
+++ b/docs/pipelines/repos/github.md
@@ -135,7 +135,7 @@ There are 3 authentication types for granting Azure Pipelines access to your Git
 
 ## Integrate using the GitHub App
 
-The Azure Pipelines GitHub App is the **recommended** authentication type. By installing it in your GitHub account or organization, your pipeline can run without using your personal GitHub identity. Builds and GitHub status updates will be performed using the Azure Pipelines identity. The app works with [GitHub Checks](https://developer.github.com/v3/checks/) to display build, test, and code coverage results in GitHub.
+By installing it in your GitHub account or organization, your pipeline can run without using your personal GitHub identity. Builds and GitHub status updates will be performed using the Azure Pipelines identity. The app works with [GitHub Checks](https://developer.github.com/v3/checks/) to display build, test, and code coverage results in GitHub.
 
 ### Install the GitHub App
 


### PR DESCRIPTION
I am a MS Azure DevOps CSS engineer. Just had a case with a customer where the PG[Azure DevOps Product Group] suggested to move service connection from using the GitHub Azure Pipelines Application to a connection based on OAuth/PAT stating that they are aware of issues when creating webhooks when GitHub service connection is made using Azure Pipelines GitHub app. Therefore I request the documentation team to erase the line where we [Microsoft] state the GitHub app is the recommended authentication type. See DTS https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1495099