### PR TITLE
Complete CLI steps using Azure DevOps extension

### DIFF
--- a/docs/repos/git/share-your-code-in-git-cmdline.md
+++ b/docs/repos/git/share-your-code-in-git-cmdline.md
@@ -21,13 +21,25 @@ This guide shows you how to share your code in a Git repo in Azure Repos using t
 
 The instructions below use the default bash shell used on Linux and macOS, but the Git commands will work in any shell, including Git Bash from Git for Windows.
 
-> [!NOTE]
-> You can also create and get repos from the command line or scripts using the [Azure DevOps Services CLI](/cli/azure/ext/azure-devops/?view=azure-cli-latest).
-
 ## Prerequisites
 
 * An organization in Azure DevOps. If you don't have an organization, you can [sign up](../../organizations/accounts/create-organization.md) for one for free. Each organization includes free, unlimited private Git repositories.
 
+## Download and install Azure CLI and add Azure DevOps extension
+1. [Install the Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli). You must have at least `v2.0.49`, which you can verify with `az --version` command.
+
+1. Add the Azure DevOps Extension `az extension add --name azure-devops`
+
+2. Run the `az login` command.
+
+    If the CLI can open your default browser, it will do so and load a sign-in page. Otherwise, you need to open a
+    browser page and follow the instructions on the command line to enter an authorization code after navigating to
+    [https://aka.ms/devicelogin](https://aka.ms/devicelogin) in your browser. For more information, see the
+    [Azure CLI login page](https://docs.microsoft.com/cli/azure/authenticate-azure-cli?view=azure-cli-latest).
+  
+ 3. For seamless commanding, set the organization and project as defaults in configuration.
+ 
+    `az devops configure --defaults organization=https://dev.azure.com/contoso project=contoso`
 ## Download and install Git
 
 * [Windows](#windows)
@@ -82,11 +94,45 @@ Create a local Git repo for your code. If your code is already in a local Git re
 
 ## Create your Git repo in Azure Repos
 
-0. [Create a new Git repo in Azure Repos](create-new-repo.md) for your code. Copy the clone URL once you are done creating your repo.
+1. Create a new Git repo in Azure Repos for your code. 
 
-   ![Get the clone URL after creating the Git repo in Azure Repos](_img/share-your-code-in-git-cmdline/clone_url.png)
+   ```
+   az repos create --name FabrikamApp
+   ```
+   
+2. Copy the clone URL from the remote URL attribute in the JSON output.
+    
+   ```
+   $ az repos create --name FabrikamApp
+   
+   [
+    {          
+        "defaultBranch": null,
+        "id": "fa3ee42f-519d-4633-8e31-4a84de343ca3",
+        "isFork": null,
+        "name": "FabrikamApp",
+        "parentRepository": null,
+        "project": {
+          "abbreviation": null,
+          "description": "This is the pipeline project for github repo",
+          "id": "fa3ee42f-519d-4633-8e31-4a84de343ca4",
+          "lastUpdateTime": "2019-04-09T08:32:15.977Z",
+          "name": "Fabrikam",
+          "revision": 255,
+          "state": "wellFormed",
+          "url": "https://dev.azure.com/fabrikops2/_apis/projects/fa3ee42f-519d-4633-8e31-4a84de343ca4",
+          "visibility": "public"
+        },
+        "remoteUrl": "https://dev.azure.com/fabrikops2/Fabrikam/_git/FabrikamApp",
+        "size": 0,
+        "sshUrl": "fabrikops2@vs-ssh.visualstudio.com:v3/fabrikops2/Fabrikam/FabrikamApp",
+        "url": "https://dev.azure.com/fabrikops2/fa3ee42f-519d-4633-8e31-4a84de343ca4/_apis/git/repositories/fa3ee42f-519d-4633-8e31-4a84de343ca3",
+        "validRemoteUrls": null
+      }
+    ]
+   ```
 
-0. Connect your local repo to the Git repo in Azure Repos using the copied clone URL in the `git remote` command:
+3. Connect your local repo to the Git repo in Azure Repos using the copied clone URL in the `git remote` command:
 
     ```
     git remote add origin https://dev.azure.com/fabrikops2/Fabrikam/_git/FabrikamApp


### PR DESCRIPTION
With the new Azure DevOps extension to Azure CLI, the document to create repository using CLI should be self sufficient without any portal interaction and the above document reflects that.