### PR TITLE
Use a valid example for the testAssemblyVer2 property

### DIFF
--- a/docs/pipelines/tasks/_shared/yaml/VsTestV2.md
+++ b/docs/pipelines/tasks/_shared/yaml/VsTestV2.md
@@ -4,7 +4,10 @@
 - task: VSTest@2
   inputs:
     #testSelector: 'testAssemblies' # Options: testAssemblies, testPlan, testRun
-    #testAssemblyVer2: '**\*test*.dll!**\*TestAdapter.dll!**\obj\**' # Required when testSelector == TestAssemblies
+    #testAssemblyVer2: | # Required when testSelector == TestAssemblies.  Use \n in a string or use a YAML block to separate lines
+    #  **\*test*.dll
+    #  !**\*TestAdapter.dll
+    #  !**\obj\**' 
     #testPlan: # Required when testSelector == TestPlan
     #testSuite: # Required when testSelector == TestPlan
     #testConfiguration: # Required when testSelector == TestPlan


### PR DESCRIPTION
The existing sample is not valid and won't work.  Multiple users have
wasted time with a bad example.

This addresses #1580 