### PR TITLE
fix reference to release retention dialog

### DIFF
--- a/docs/pipelines/policies/retention.md
+++ b/docs/pipelines/policies/retention.md
@@ -204,7 +204,7 @@ When specifying custom policies per pipeline, you cannot exceed the maximum limi
 The build linked to a release has its own retention policy,
 which may be shorter than that of the release. If you want to retain
 the build for the same period as the release, set the
-**Retain build** checkbox for the appropriate stages. This
+**Retain associated artifacts** checkbox for the appropriate stages. This
 overrides the retention policy for the build, and ensures that the
 artifacts are available if you need to redeploy that release.
 


### PR DESCRIPTION
The dialog for release retention says **Retain associated artifacts**, not **Retain build**.