### PR TITLE
Fixed typo in MacOS High Sierra version number.

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -18,7 +18,7 @@ monikerRange: 'azure-devops'
 **Azure Pipelines**
 
 > [!NOTE]
-> Support for macOS X Mojave (10.14) is here! If you're using the 'Hosted macOS' agent pool today, your pipelines are running on Mojave. If you'd like to remain on High Sierra (10.3), then select the 'Hosted macOS High Sierra' agent pool for your pipelines.
+> Support for macOS X Mojave (10.14) is here! If you're using the 'Hosted macOS' agent pool today, your pipelines are running on Mojave. If you'd like to remain on High Sierra (10.13), then select the 'Hosted macOS High Sierra' agent pool for your pipelines.
 
 [!INCLUDE [include](_shared/hosted-agent-intro.md)]
 


### PR DESCRIPTION
On line 21, fixed a typo: "High Sierra (10.3)" should be "High Sierra (10.13)"