### PR TITLE
Un-comment AzureKeyVault@1 secretsFilter argument

### DIFF
--- a/docs/pipelines/tasks/_shared/yaml/AzureKeyVaultV1.md
+++ b/docs/pipelines/tasks/_shared/yaml/AzureKeyVaultV1.md
@@ -5,5 +5,5 @@
   inputs:
     azureSubscription: 
     keyVaultName: 
-    #secretsFilter: '*' # Options: editableOptions
+    secretsFilter: '*'
 ```


### PR DESCRIPTION
According to the [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-key-vault?view=azure-devops#arguments), the `secretsFilter` argument is required. As such, this change un-comments the argument in the snippet to avoid potential confusion for users since having the argument commented-out may be interpreted as the argument being optional.