### PR TITLE
Add newlines between match expressions in testAssemblyVer2

### DIFF
--- a/docs/pipelines/tasks/_shared/yaml/VsTestV2.md
+++ b/docs/pipelines/tasks/_shared/yaml/VsTestV2.md
@@ -4,7 +4,7 @@
 - task: VSTest@2
   inputs:
     #testSelector: 'testAssemblies' # Options: testAssemblies, testPlan, testRun
-    #testAssemblyVer2: '**\*test*.dll!**\*TestAdapter.dll!**\obj\**' # Required when testSelector == TestAssemblies
+    #testAssemblyVer2: "**\\*test*.dll\n!**\\*TestAdapter.dll\n!**\\obj\\**" # Required when testSelector == TestAssemblies
     #testPlan: # Required when testSelector == TestPlan
     #testSuite: # Required when testSelector == TestPlan
     #testConfiguration: # Required when testSelector == TestPlan


### PR DESCRIPTION
The example for testing using `VSTest@2` assembly pattern matching expressions contains 3 expressions with no separation. If you try to copy and paste the sample into your own YAML it won't work correctly. 

Had it not been for issue #1580 clarifying this, I would have wasted a lot of time figuring this out. 

This PR adds newline characters to separate the example expressions.