### PR TITLE
fixing small typo

### DIFF
--- a/docs/pipelines/languages/javascript.md
+++ b/docs/pipelines/languages/javascript.md
@@ -41,7 +41,7 @@ https://github.com/MicrosoftDocs/pipelines-javascript
 ::: moniker range="azure-devops"
 
 Follow all the instructions in [Create your first pipeline](../create-first-pipeline.md) to create a pipeline for the sample app.
-When you're done with that topic, you'll have a working YAML file (`azure-pipeines.yml`) in your repository that you can continue to modify by following the instructions in this topic. To learn more about YAML, see [YAML schema reference](../yaml-schema.md).
+When you're done with that topic, you'll have a working YAML file (`azure-pipelines.yml`) in your repository that you can continue to modify by following the instructions in this topic. To learn more about YAML, see [YAML schema reference](../yaml-schema.md).
 
 ::: moniker-end
 


### PR DESCRIPTION
fixing a small typo from azure-pipeines.yml to azure-pipelines.yml