### PR TITLE
Added comma to the invalid docfx.json

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -37,7 +37,7 @@
     "externalReference": [],
     "globalMetadata": {
       "brand": "azure-devops",
-      "searchScope": ["Azure DevOps" "VSTS", "Team Services"],
+      "searchScope": ["Azure DevOps", "VSTS", "Team Services"],
       "author": "erickson-doug",
       "ms.author": "jillfra",
       "ms.topic": "conceptual",


### PR DESCRIPTION
The JSON format was not valid. Therefore, I added a comma.