### PR TITLE
Rename ASP.NET Core to ASP.NET

### DIFF
--- a/docs/pipelines/apps/aspnet/build-aspnet-4.md
+++ b/docs/pipelines/apps/aspnet/build-aspnet-4.md
@@ -52,7 +52,7 @@ The sample app is a Visual Studio solution that has two projects: An ASP.NET Web
 > This scenario works on TFS, but some of the following instructions might not exactly match the version of TFS that you are using. Also, you'll need to set up a self-hosted agent, possibly also installing software. If you are a new user, you might have a better learning experience by trying this procedure out first using a free Azure DevOps organization. Then change the selector in the upper-left corner of this page from Team Foundation Server to **Azure DevOps**.
 ::: moniker-end
 
-* After you have the sample code in your own repository, create a pipeline using the instructions in [Create your first pipeline](../../create-first-pipeline.md) and select the **ASP.NET Core** template. This automatically adds the tasks required to build the code in the sample repository.
+* After you have the sample code in your own repository, create a pipeline using the instructions in [Create your first pipeline](../../create-first-pipeline.md) and select the **ASP.NET** template. This automatically adds the tasks required to build the code in the sample repository.
 
 * Save the pipeline and queue a build to see it in action.
 


### PR DESCRIPTION
In this set of instructions for getting an ASP.NET application template for pipelines the documentation incorrectly states that one should select the ASP.NET Core template. This fix corrects that to the "older" ASP.NET Template.