### PR TITLE
Fix extra dot in the pipeline "name"

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -9,7 +9,7 @@ ms.manager: jillfra
 ms.author: macoope
 author: vtbassmatt
 ms.reviewer: macoope
-ms.date: 04/17/2019
+ms.date: 05/06/2019
 monikerRange: '>= azure-devops-2019'
 ---
 

--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -162,7 +162,7 @@ steps: [ script | bash | pwsh | powershell | checkout | task | templateReference
 # [Example](#tab/example)
 
 ```yaml
-name: $(Date:yyyyMMdd).$(Rev:.r)
+name: $(Date:yyyyMMdd)$(Rev:.r)
 variables:
   var1: value1
 jobs:


### PR DESCRIPTION
When using the example YAML, the build name ends up having an extra dot:

`20190506..1`

This change will make correct it:

`20190506.1`

Fixes #4154