### PR TITLE
Fix quotes on example

### DIFF
--- a/docs/pipelines/process/expressions.md
+++ b/docs/pipelines/process/expressions.md
@@ -130,7 +130,7 @@ You can create a counter that is automatically incremented by one in each execut
 variables:
   major: 1
   # define b as a counter with the prefix as variable a, and seed as 100.
-  minor: $[counter(variables[`major`], 100)]
+  minor: $[counter(variables['major'], 100)]
 
 steps:
     - bash: echo $(minor)


### PR DESCRIPTION
The correct syntax for referencing variables uses single quotes, not backticks. This fixes an example in the doc