### PR TITLE
Self-hosted public projects has unlimited parallel jobs

### DIFF
--- a/docs/pipelines/licensing/concurrent-jobs.md
+++ b/docs/pipelines/licensing/concurrent-jobs.md
@@ -41,7 +41,7 @@ If you want Azure Pipelines to orchestrate your builds and releases, but use you
 
 We provide a *free tier* of service by default in your organization:
 
-- Public project: 10 free self-hosted parallel jobs.
+- Public project: Unlimited self-hosted parallel jobs.
 - Private project: One self-hosted parallel job. Additionally, for each active Visual Studio Enterprise subscriber who is a member of your organization, you get one additional self-hosted parallel job.
 
 When the free tier is no longer sufficient:


### PR DESCRIPTION
I created a new Azure DevOps organization and in the Parallel Jobs tab it says that I have unlimited parallel jobs for self-hosted agents.

![image](https://user-images.githubusercontent.com/1991286/58585131-3a50ef80-822e-11e9-8be8-36e6418e6ce2.png)
