### PR TITLE
Direct link to JSON schema on github

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1495,4 +1495,4 @@ extension. You can [download VS Code](https://code.visualstudio.com),
 <!-- For people who get here by searching for, say, "azure pipelines template YAML schema",
      look around a bit, and then type "Ctrl-F JSON" when they don't see anything promising
      in the first few screenfuls. -->
-The extension includes a [JSON schema for azure pipeline definitions](https://github.com/microsoft/azure-pipelines-vscode/blob/master/service-schema.json) for validation. 
+The extension includes a [JSON schema](https://github.com/microsoft/azure-pipelines-vscode/blob/master/service-schema.json) for validation.

--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1492,3 +1492,7 @@ Syntax highlighting is available for the pipeline schema via a VS Code
 extension. You can [download VS Code](https://code.visualstudio.com),
 [install the extension](https://marketplace.visualstudio.com/items?itemName=ms-azure-devops.azure-pipelines), and
 [check out the project on GitHub](https://github.com/Microsoft/azure-pipelines-vscode).
+<!-- For people who get here by searching for, say, "azure pipelines template YAML schema",
+     look around a bit, and then type "Ctrl-F JSON" when they don't see anything promising
+     in the first few screenfuls. -->
+The extension includes a [JSON schema for azure pipeline definitions](https://github.com/microsoft/azure-pipelines-vscode/blob/master/service-schema.json) for validation. 


### PR DESCRIPTION
By the time I spotted the "Syntax highlighting" heading and thought "Does that come with a side of YAML validation?", I had nearly finished writing an issue complaining that this page did not link to a JSON schema.

Because my first thought when confronted with a YAML file that has a lot of properties that could use explaining is not "I want Syntax Highlighting".