### PR TITLE
Updating URL samples to new format in npmrc.md

### DIFF
--- a/docs/artifacts/_shared/npm/npmrc.md
+++ b/docs/artifacts/_shared/npm/npmrc.md
@@ -53,8 +53,8 @@ The **Connect to feed** dialog box generates an appropriately formatted token th
 1. In your $home/.npmrc file, add the following lines. Replace `yourorganization` and `yourfeed`, and add your username (can be anything except empty), PAT, and email.
 
    ```ini
-   //pkgs.dev.azure.com/<yourorganization>/_packaging/<yourfeed>/npm/registry/:username=ANYTHING-BUT-EMPTY
-   //pkgs.dev.azure.com/<yourorganization>/_packaging/<yourfeed>/npm/registry/:_password=BASE64-ENCODED-PAT-GOES-HERE
-   //pkgs.dev.azure.com/<yourorganization>/_packaging/<yourfeed>/npm/registry/:email=YOUREMAIL@EXAMPLE.COM
-   //pkgs.dev.azure.com/<yourorganization>/_packaging/<yourfeed>/npm/registry/:always-auth=true
+   //<yourorganization>.pkgs.visualstudio.com/_packaging/<yourfeed>/npm/registry/:username=ANYTHING-BUT-EMPTY
+   //<yourorganization>.pkgs.visualstudio.com/_packaging/<yourfeed>/npm/registry/:_password=BASE64-ENCODED-PAT-GOES-HERE
+   //<yourorganization>.pkgs.visualstudio.com/_packaging/<yourfeed>/npm/registry/:email=YOUREMAIL@EXAMPLE.COM
+   //<yourorganization>.pkgs.visualstudio.com/_packaging/<yourfeed>/npm/registry/:always-auth=true
    ```


### PR DESCRIPTION
The previous URLs used in the Create a token that lasts longer than 90 days section were using the old format of URL for the artifacts NPM feeds, not the new style that are now being used. This caused me to waste a long time debugging an authentication error as I didn't notice the difference in URL format.