### PR TITLE
Remove link to dead extension.

### DIFF
--- a/docs/project/feedback/index.md
+++ b/docs/project/feedback/index.md
@@ -43,5 +43,4 @@ To provide feedback about Azure DevOps Services or TFS, see [Provide product and
 ## Resources 
 
 - [Uservoice Integration (Marketplace extension)](https://marketplace.visualstudio.com/items?itemName=ms-vsts.services-uservoice)  
-- [UserVoice UI (Marketplace extension)](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.vsts-uservoice-ui)  
 


### PR DESCRIPTION
As mentioned on the extension page:

> This extension is now unpublished from Marketplace. You can choose to uninstall it.