### PR TITLE
Change publish to upload

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1461,7 +1461,7 @@ Learn more about [conditions](process/conditions.md?tabs=yaml) and
 [timeouts](process/phases.md?tabs=yaml#timeouts).
 
 ::: moniker range="azure-devops"
-## Publish
+## Upload
 
 `upload` is a shortcut for the [Publish Pipeline Artifact task](tasks/utility/publish-pipeline-artifact.md). It will publish (upload) a file or folder as a pipeline artifact that can be consumed by other jobs and pipelines.
 

--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1463,13 +1463,13 @@ Learn more about [conditions](process/conditions.md?tabs=yaml) and
 ::: moniker range="azure-devops"
 ## Publish
 
-`publish` is a shortcut for the [Publish Pipeline Artifact task](tasks/utility/publish-pipeline-artifact.md). It will publish (upload) a file or folder as a pipeline artifact that can be consumed by other jobs and pipelines.
+`upload` is a shortcut for the [Publish Pipeline Artifact task](tasks/utility/publish-pipeline-artifact.md). It will publish (upload) a file or folder as a pipeline artifact that can be consumed by other jobs and pipelines.
 
 # [Schema](#tab/schema)
 
 ```yaml
 steps:
-- publish: string # path to a file or folder
+- upload: string # path to a file or folder
   artifact: string # artifact name
 ```
 
@@ -1477,7 +1477,7 @@ steps:
 
 ```yaml
 steps:
-- publish: $(Build.SourcesDirectory)/build
+- upload: $(Build.SourcesDirectory)/build
   artifact: WebApp
 ```
 


### PR DESCRIPTION
The docs indicate to use `publish` as a shorthand syntax for the `PublishPipelineArtifact` task.

As of 2019-06-21, this does not work, at least for my Azure DevOps organization. VS Code autocomplete using the YAML schema led me to use `upload` instead, which resulted in a passing build.

I noticed there was a previous commit from @willsmythe that had already changed this from `upload` -> `publish`: https://github.com/MicrosoftDocs/vsts-docs/commit/fb46c145692ed01e891bef2269ffb076a45420fd#diff-bcc10bee92dca0aee3b30d42a1d4199e

If the long-term shortcut is to be `publish`, and it's waiting on a server-side YAML schema and/or deployment rollout, please feel free to close this out and I'll wait it out :) Right now, it seems like the doc is incorrect, so this PR is a proposed fix that works for me

Failing build using `publish`: https://dev.azure.com/noelbundick/samples/_build/results?buildId=649&view=results

Working build using `upload`: https://dev.azure.com/noelbundick/samples/_build/results?buildId=651&view=results

