### PR TITLE
Update xamarin.md

### DIFF
--- a/docs/pipelines/languages/xamarin.md
+++ b/docs/pipelines/languages/xamarin.md
@@ -71,7 +71,7 @@ steps:
 
 ### Sign a Xamarin.Android app
 
-See [Sign your mobile app during CI](../apps/mobile/app-signing.md) for information about signing your app.
+See [Sign your mobile Android app during CI](https://docs.microsoft.com/en-us/azure/devops/pipelines/apps/mobile/app-signing?view=azure-devops&tabs=apple-install-during-build#sign-your-android-app) for information about signing your app.
 
 ### Next steps
 
@@ -101,9 +101,11 @@ steps:
     buildForSimulator: true
 ```
 
-### Sign and provision a Xamarin.iOS app
+### Sign and provision a Xamarin.iOS app - The PackageApp option
 
-To sign and provision a Xamarin.iOS app, set `packageApp` to `true` and specify a signing identity and provisioning profile ID:
+To generate a signed and provisioned a Xamarin.iOS app .ipa package, set `packageApp` to `true` and make sure prior to this task you installed the right Apple Provisioning Profile and Apple Certificates that match your App Bundle ID into the agent running the job.
+
+To fulfill these mandatory requisites use the Microsoft Provided tasks for [installing an Apple Provisioning Profile](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/install-apple-provisioning-profile?view=azure-devops) and [installing Apple Certificates](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/install-apple-certificate?view=azure-devops).
 
 ```yaml
 - task: XamariniOS@2
@@ -111,11 +113,31 @@ To sign and provision a Xamarin.iOS app, set `packageApp` to `true` and specify 
       solutionFile: '**/*iOS.csproj'
       configuration: 'AppStore'
       packageApp: true
-      signingIdentity: 'iPhone Developer: Chris Sidi (7RZ3N927YF)'
-      signingProvisioningProfileID: 'iOS Team Provisioning Profile: com.hashtagchris.*'
 ```
+> [!TIP]
+> The Xamarin.iOS build task will <u>only</u> generate an .ipa package if the agent running the job has the [appropriate provisioning profile and Apple certificate installed](https://docs.microsoft.com/en-us/azure/devops/pipelines/apps/mobile/app-signing?view=azure-devops&tabs=apple-install-during-build#sign-your-apple-ios-macos-tvos-or-watchos-app). If you enable the packageApp option and the agent does not have the appropriate apple provisioning profile and apple certificate the build may report succeeded but there will be no .ipa generated.
 
-See [Sign your mobile app during CI](../apps/mobile/app-signing.md) for more information about signing and provisioning your app.
+For Microsoft Hosted agents the .ipa package is by default located under path:  
+`{iOS.csproj root}/bin/{Configuration}/{iPhone/iPhoneSimulator}/`
+
+You can configure the output path by adding an argument to the Xamarin.iOS task as following:
+
+# [YAML](#tab/yaml)
+```yaml
+- task: XamariniOS@2
+    inputs:
+      solutionFile: '**/*iOS.csproj'
+      configuration: 'AppStore'
+      packageApp: true
+      args: /p:IpaPackageDir="/Users/vsts/agent/2.153.2/work/1/a"
+```
+This example locates the .ipa in the Build Artifact Staging Directoy ready to be pushed into Azure DevOps as an artifact to each build run.To push it into Azure DevOps simply add a [Publish Artifact task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-build-artifacts?view=azure-devops) to the end of your pipeline.
+
+See [Sign your mobile iOS app during CI](https://docs.microsoft.com/en-us/azure/devops/pipelines/apps/mobile/app-signing?view=azure-devops&tabs=apple-install-during-build#sign-your-apple-ios-macos-tvos-or-watchos-app) for more information about signing and provisioning your iOS app.
+
+# [Classic](#tab/classic)
+Expand menu Advanced for the Xamarin.iOS build task and add **/p:IpaPackageDir="/Users/vsts/agent/2.153.2/work/1/a"** in the input field Arguments to place the generated .ipa package in the Build Artifact Staging Directory. To push it into Azure DevOps simply add a [Publish Artifact task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-build-artifacts?view=azure-devops) to the end of your pipeline. 
+
 
 ### Set the Xamarin SDK version on macOS
 


### PR DESCRIPTION
We're proposing this change to the docs because we recently had a hard time configuring the Xamarin.iOS build task to produce an .ipa package for CI/CD in Azure Pipelines. We had to troubleshoot a lot and we even had to perform the build using a regular bash task to finally find out that we were passing a wrong apple certificate. The Xamarin.iOS task never through an error but we noticed no .ipa file was being generated at all by carefully reviewing the folders of the agent, somehow a regular bash msbuild command provided more information pointing we were missing signing identities for the app bundle id.

After understanding the issue we guessed it be good idea to share this with our customer through this docs.
Hopefully, you'll find our contribution useful. Proposing this with @ManuelGalindo we're both Azure DevOps support engineers. Pending for corrections if needed we can provide a visual guide with screenshots for the classic pipeline tab.