### PR TITLE
fixed 'install dotnetsay' task

### DIFF
--- a/docs/pipelines/languages/dotnet-core.md
+++ b/docs/pipelines/languages/dotnet-core.md
@@ -283,7 +283,6 @@ steps:
   displayName: 'Install dotnetsay'
   inputs:
     command: custom
-    projects: '**/*.csproj'
     custom: tool
     arguments: 'install -g dotnetsay'
 ```


### PR DESCRIPTION
This PR removes the erroneously placed 'project' attribute in the 'install dotnetsay' step. The step only works correctly with it removed.