### PR TITLE
use-ssh-keys-to-authenticate.md: explain how manage multiple keys

### DIFF
--- a/docs/repos/git/use-ssh-keys-to-authenticate.md
+++ b/docs/repos/git/use-ssh-keys-to-authenticate.md
@@ -264,6 +264,78 @@ You can find `ssh-add` as part of the Git for Windows distribution and also run 
 On macOS and Linux you also must have `ssh-agent` running before running `ssh-add`, but the command environment on these platforms usually 
 takes care of starting `ssh-agent` for you.
 
+### I have multiple SSH keys.  How do I use different SSH keys for different SSH servers or repos?
+Generally, if you configure multiple keys for an SSH client and connect to an SSH server, the client can try the keys one at a time until the server accepts one.
+
+However, this doesn't work with Azure DevOps for technical reasons related to the SSH protocol and how our Git SSH URLs are structured.  Azure DevOps will blindly accept the first key that the client provides during authentication.  If that key is invalid for the requested repo, the request will fail with the following error:
+> ```
+> remote: Public key authentication failed.
+> fatal: Could not read from remote repository.
+> ```
+
+For Azure DevOps, you'll need to configure SSH to explicitly use a specific key file.  One way to do this to edit your `~/.ssh/config` file (for example, `/home/jamal/.ssh` or `C:\Users\jamal\.ssh`) as follows:
+```
+# The settings in each Host section are applied to any Git SSH remote URL with a matching hostname.
+# Generally:
+# * SSH uses the first matching line for each parameter name, e.g. if there's multiple values for a
+#   parameter across multiple matching Host sections
+# * "IdentitiesOnly yes" prevents keys cached in ssh-agent from being tried before the IdentityFile
+#   values we explicitly set.
+# * On Windows, ~/.ssh/your_public_key maps to %USERPROFILE%\.ssh\your_public_key, e.g.
+#   C:\Users\<username>\.ssh\your_public_key.
+
+# To use the same key across all hosted Azure DevOps organizations, where the SSH URL host is
+# ssh.dev.azure.com (like git@ssh.dev.azure.com:v3/some_organization/some_project/some_repo), add
+# the Host section below:
+Host ssh.dev.azure.com
+IdentityFile ~/.ssh/your_public_key
+IdentitiesOnly yes
+
+# Since all hosted Azure DevOps URLs have the same hostname (ssh.dev.azure.com), if you need
+# different keys for different organizations (or just different repos within the same organization),
+# you'll need to use host aliases to create separate Host sections.
+#
+# Imagine that we have the following two SSH URLs:
+# * git@ssh.dev.azure.com:v3/org1/org1_project/org1_repo
+#   * For this, we want to use key1, so we'll use devops_key1 as the Host alias.
+# * git@ssh.dev.azure.com:v3/org2/org2_project/org2_repo
+#   * For this, we want to use key2, so we'll use devops_key2 as the Host alias.
+#
+# You'll need to substitute ssh.dev.azure.com with the Host alias in the SSH URL you use with Git.
+# The SSH URLs above become:
+# * git@devops_key1:v3/org1/org1_project/org1_repo
+# * git@devops_key2:v3/org2/org2_project/org2_repo
+#
+# To set explicit keys for the two host aliases and to tell SSH to use the correct actual hostname,
+# add the next two Host sections:
+Host devops_key1
+HostName ssh.dev.azure.com
+IdentityFile ~/.ssh/public_key_for_org1
+IdentitiesOnly yes
+Host devops_key2
+HostName ssh.dev.azure.com
+IdentityFile ~/.ssh/public_key_for_org2
+IdentitiesOnly yes
+
+# If you have an SSH URL where the hostname is vs-ssh.visualstudio.com, from when Azure DevOps was
+# formerly called Visual Studio Team Services, add the following Host section.
+# Alternately, you can just replace the hostname in your SSH URL with ssh.dev.azure.com.  Both
+# ssh.dev.azure.com and vs-ssh.visualstudio.com point to the same place.
+Host vs-ssh.visualstudio.com
+IdentityFile ~/.ssh/your_public_key
+IdentitiesOnly yes
+
+# If you have an on-premises Azure DevOps Server instance, where SSH URLs look like
+# ssh://someHost:22/someCollection/some_project/_git/some_repo, add the following Host section:
+Host someHost
+IdentityFile ~/.ssh/your_public_key
+IdentitiesOnly yes
+
+# Put global defaults here.  Note that "*" also matches any hosts that match the sections above, and
+# remember that SSH uses the first matching line for each parameter name.
+Host *
+```
+
 ### What notifications may I receive regarding my SSH keys?
 
 Whenever you register a new SSH Key with Azure DevOps Services, you will receive an email notification informing you that a new SSH key has been added to your account.


### PR DESCRIPTION
If an SSH client is configured with multiple keys, Azure DevOps behaves differently from most SSH servers.

This has been confusing for customers in the past, e.g. https://developercommunity.visualstudio.com/content/problem/187823/git-ssh-fails-when-multiple-ssh-keys-are-in-the-ag.html