### PR TITLE
fix: MD014/commands-show-output

### DIFF
--- a/docs/project/wiki/markdown-guidance.md
+++ b/docs/project/wiki/markdown-guidance.md
@@ -240,7 +240,7 @@ To indicate a span of code, wrap it with three backtick quotes (<code>&#96;&#96;
 **Example:**
 
 <pre>&#96;&#96;&#96;
-$ sudo npm install vsoagent-installer -g  
+sudo npm install vsoagent-installer -g  
 &#96;&#96;&#96;
 </pre>  
 
@@ -249,7 +249,7 @@ $ sudo npm install vsoagent-installer -g
 **Result:**
 
 ```
-$ sudo npm install vsoagent-installer -g
+sudo npm install vsoagent-installer -g
 ```
 
 <br/>


### PR DESCRIPTION

Dollar signs used before commands without showing output