### PR TITLE
Fixed password variable settings.

### DIFF
--- a/docs/pipelines/languages/docker.md
+++ b/docs/pipelines/languages/docker.md
@@ -252,7 +252,7 @@ variables:
 steps:
 - script: |
     docker build -t $(dockerId)/$(imageName) .
-    docker login -u $(dockerId) -p $(pswd)
+    docker login -u $(dockerId) -p $pswd
     docker push $(dockerId)/$(imageName)
   env:
     pswd: $(dockerPassword)        # Define dockerPassword in the Variables tab of this pipeline in Pipelines page of web interface
@@ -268,7 +268,7 @@ variables:
 steps:
 - script: |
     docker build -t $(dockerId).azurecr.io/$(imageName) .
-    docker login -u $(dockerId) -p $(pswd) $(dockerId).azurecr.io
+    docker login -u $(dockerId) -p $pswd $(dockerId).azurecr.io
     docker push $(dockerId).azurecr.io/$(imageName)
   env:
     pswd: $(dockerPassword)        # Define dockerPassword in the Variables tab of this pipeline in Pipelines page of web interface


### PR DESCRIPTION
$(pswd) didn't work. It should be $pswd
I suppose these are mistakes.
Should change from $(pswd) to $pswd, or from $(pswd) to $(dockerPassword) because variable pswd is defined on env section.