### PR TITLE
Update advanced-code-search-syntax.md

### DIFF
--- a/docs/project/search/advanced-code-search-syntax.md
+++ b/docs/project/search/advanced-code-search-syntax.md
@@ -186,45 +186,45 @@ C#, C, C++, Java, and Visual Basic.NET code.
 
 | To find code where _findThis_ appears as a ... | ... search for argument **arg:**_findThis_ |
 | --- | --- |
-| Argument | **arg:**_findThis_ | 
+| Argument | **arg:**_findThis_ ```Deprecated in July 2019```| 
 | Base type | **basetype:**_findThis_ | 
-| Calling function | **caller:**_findThis_ |
+| Calling function | **caller:**_findThis_ ```Deprecated in July 2019```|
 | Class definition or declaration | **class:**_findThis_ |
-| Class declaration | **classdecl:**_findThis_ |
-| Class definition | **classdef:**_findThis_ |
+| Class declaration | **classdecl:**_findThis_ ```Merged with class:```|
+| Class definition | **classdef:**_findThis_  ```Merged with class:```|
 | Comment | **comment:**_findThis_ |
-| Constructor | **ctor:**_findThis_ |
+| Constructor | **ctor:**_findThis_ ```Merged with method:```|
 | Declaration | **decl:**_findThis_ |
 | Definition | **def:**_findThis_ |
-| Destructor | **dtor:**_findThis_ |
+| Destructor | **dtor:**_findThis_ ```Merged with method:```|
 | Enumerator | **enum:**_findThis_ |
-| Extern | **extern:**_findThis_ |
+| Extern | **extern:**_findThis_ ```Deprecated in July 2019```|
 | Field | **field:**_findThis_ |
-| Friend function | **friend:**_findThis_ |
-| Function | **func:**_findThis_ |
-| Function declaration | **funcdecl:**_findThis_ |
-| Function definition | **funcdef:**_findThis_ |
-| Global | **global:**_findThis_ |
-| Header | **header:**_findThis_ |
+| Friend function | **friend:**_findThis_ ```Deprecated in July 2019```|
+| Function | **func:**_findThis_ ```Merged with method:```|
+| Function declaration | **funcdecl:**_findThis_ ```Merged with method:```|
+| Function definition | **funcdef:**_findThis_ ```Merged with method:```|
+| Global | **global:**_findThis_ ```Deprecated in July 2019```|
+| Header | **header:**_findThis_ ```Deprecated in July 2019```|
 | Interface | **interface:**_findThis_ |
 | Macro | **macro:**_findThis_ |
-| Macro definition | **macrodef:**_findThis_ |
-| Macro reference | **macroref:**_findThis_ |
+| Macro definition | **macrodef:**_findThis_ ```Merged with macro:```|
+| Macro reference | **macroref:**_findThis_ ```Merged with macro:```|
 | Method | **method:**_findThis_ |
-| Method declaration | **methoddecl:**_findThis_ |
-| Method definition | **methoddef:**_findThis_ |
+| Method declaration | **methoddecl:**_findThis_ ```Merged with method:```|
+| Method definition | **methoddef:**_findThis_ ```Merged with method:```|
 | Namespace | **namespace:**_findThis_ |
 | Property | **prop:**_findThis_ |
 | Reference | **ref:**_findThis_ |
 | String literal | **strlit:**_findThis_ |
-| Struct | **struct:**_findThis_ |
-| Struct declaration | **structdecl:**_findThis_ |
-| Struct definition | **structdef:**_findThis_ |
-| Template argument | **tmplarg:**_findThis_ |
-| Template specification | **tmplspec:**_findThis_ |
+| Struct | **struct:**_findThis_ ```Merged with type:```|
+| Struct declaration | **structdecl:**_findThis_ ```Merged with type:```|
+| Struct definition | **structdef:**_findThis_ ```Merged with type:```|
+| Template argument | **tmplarg:**_findThis_ ```Deprecated in July 2019```|
+| Template specification | **tmplspec:**_findThis_ ```Deprecated in July 2019```|
 | Type | **type:**_findThis_ |
-| Typedef | **typedef:**_findThis_ |
-| Union | **union:**_findThis_ |
+| Typedef | **typedef:**_findThis_ ```Merged with type:```|
+| Union | **union:**_findThis_ ```Deprecated in July 2019```|
 
 <a name="locationfunctions"></a>
 ## Functions to select projects, repositories, paths, and files


### PR DESCRIPTION
We are not supporting certain code search filters in S155 update. Updated the change in the documentation. In 2 sprints we should remove all the filters marked as not supported.