### PR TITLE
Update AppCenterDistributeV3.md

### DIFF
--- a/docs/pipelines/tasks/_shared/yaml/AppCenterDistributeV3.md
+++ b/docs/pipelines/tasks/_shared/yaml/AppCenterDistributeV3.md
@@ -18,6 +18,6 @@
     #isMandatory: false # Optional
     #destinationType: 'groups' # Options: groups, store
     #distributionGroupId: # Optional
-    #destinationStoreId: # Required when destinationType == Store
+    #destinationStoreId: # Required when destinationType == store
     #isSilent: # Optional
 ```


### PR DESCRIPTION
Replaced misleading uppercase example of `destinationType`:
`store` instead of `Store` as uppercase is not supported