### PR TITLE
fixing typo in first sentence in Analytics section

### DIFF
--- a/docs/report/powerbi/reporting-roadmap.md
+++ b/docs/report/powerbi/reporting-roadmap.md
@@ -27,7 +27,7 @@ The future of reporting for Azure DevOps and Azure DevOps Server is Analytics.
 
 ::: moniker range="azure-devops"
 
-Analytics in available for all organizations using Azure DevOps Services. It provides several [advanced widgets](../dashboards/analytics-widgets.md). [Power BI integration](index.md) and access to the [OData feed](../extend-analytics/index.md) of Analytics remain in Preview. 
+Analytics is available for all organizations using Azure DevOps Services. It provides several [advanced widgets](../dashboards/analytics-widgets.md). [Power BI integration](index.md) and access to the [OData feed](../extend-analytics/index.md) of Analytics remain in Preview. 
 
 ::: moniker-end
 


### PR DESCRIPTION
The first sentence in the Analytics section was previously the following.
`Analytics in available for all organizations using Azure DevOps Services.`
