### PR TITLE
Cleanup unused anchor and fix some section heading in add-dashboard-widget.md

### DIFF
--- a/docs/extend/develop/add-dashboard-widget.md
+++ b/docs/extend/develop/add-dashboard-widget.md
@@ -61,8 +61,6 @@ This part presents a widget that prints "Hello World" using JavaScript.
 
 ![Overview dashboard in with a sample widget](../_shared/procedures/_img/add-dashboard-widget/sample.png)
 
-<a name="step-1-files" />
-
 ### Step 1: Get the client SDK - `VSS.SDK.min.js`
 
 The core SDK script, `VSS.SDK.min.js`, enables web extensions to communicate to the host Azure DevOps Services frame. The script does operations like initializing, notifying extension is loaded, or getting context about the current page. 
@@ -101,7 +99,6 @@ Add the below HTML in `hello-world.html`. We add the mandatory reference to `VSS
 > Even though we are using an HTML file, most of the HTML head elements other than script and link are ignored by the framework.
 
 <a name="widget-javascript"/>
-
 ### Step 3: Your JavaScript
 
 We use JavaScript to render content in the widget. In this article, we wrap all of our JavaScript code inside a <code>&lt;script&gt;</code> element in the HTML file. You can choose to have this code in a separate JavaScript file and refer it in the HTML file.
@@ -132,7 +129,6 @@ In our case, below is the code that would print &quot;Hello World&quot; in the w
     </script>
 ```
 
-<a name="vss-methods"></a>
 
 `VSS.init` initializes the handshake between the iframe hosting the widget and the host frame.
 We pass `explicitNotifyLoaded: true` so that the widget can explicitly notify the host when we're done loading. This control allows us to notify load completion after ensuring that the dependent modules are loaded.
@@ -158,8 +154,6 @@ We use the `WidgetStatusHelper` from WidgetHelpers to return the `WidgetStatus` 
 
 > The `vss-extension.json` should always be at the root of the folder (in this guide, `HelloWorld`). For all the other files, you can place them in whatever structure you want inside the folder, just make sure to update the references appropriately in the HTML files and in the `vss-extension.json` manifest. 
 
-<a name="image"/>
-
 ### Step 4: Your extension&#39;s logo: <code>logo.png</code>
 
 Your logo is displayed in the Marketplace, and in the widget catalog once a user installs your extension.
@@ -169,8 +163,6 @@ You need a 98 px x 98 px catalog icon. Choose an image, name it `logo.png`, and 
 To support TFS 2015 Update 3, you need an additional image that is 330 px x 160 px. This preview image is shown in this catalog. Choose an image, name it `preview.png`, and place it in the `img` folder as before.
 
 You can name these images however you want as long as the extension manifest in the next step is updated with the names you use.
-
-<a name="widget-extension-manifest" />
 
 ### Step 5: Your extension&#39;s manifest: <code>vss-extension.json</code>
 
@@ -267,9 +259,7 @@ Set `addressable` to `true` unless you include other files that don't need to be
 >[!NOTE]
 >For more information about the **extension manifest file**, such as its properties and what they do, check out the [extension manifest reference](./manifest.md).
 
-<a name="package-publish-share"/>
-
-### Step 6: Package, Publish, and Share
+### Step 6: Package, Publish and Share
 
 Once you've written your extension, the next step towards getting it into the Marketplace is to package all of your files together. All extensions are packaged
 as VSIX 2.0 compatible .vsix files - Microsoft provides a cross-platform command line interface (CLI) to package your extension. 
@@ -280,7 +270,7 @@ You can install or update the TFS Cross Platform Command Line Interface (tfx-cli
 ```no-highlight
 npm i -g tfx-cli
 ```
- <a name="package-the-extension"/>
+
 #### Package your extension
 Packaging your extension into a .vsix file is effortless once you have the tfx-cli, navigate to your extension's home directory and run the following command.
 
@@ -325,15 +315,11 @@ You'll need a personal access token, too.
 tfx extension publish --manifest-globs your-manifest.json --share-with yourOrganization
 ```
 
-<a name="add-from-catalog"/>
-
 ### Step 7: Add Widget From the Catalog
 Now, go to your team dashboard at http://dev.azure.com/{yourOrganization}/{yourProject}. If this page is already open, then refresh it. 
 Hover on the Edit button in the bottom right, and select the Add button. This should open the widget catalog where you find the widget you installed. 
 Choose your widget and select the 'Add' button to add it to your dashboard.
 
-
-<a name="part-2"/>
 
 ## Part 2: Hello World with Azure DevOps Services REST API
 
@@ -420,7 +406,6 @@ Add the below at the end of your extension manifest.
     <b>Warning</b>: Adding or changing scopes after publishing an extension is currently not supported. If you've already uploaded your extension, remove it from the Marketplace. 
     Go to <a href="https://marketplace.visualstudio.com/manage/createpublisher" data-raw-source="[Visual Studio Marketplace Publishing Portal](https://marketplace.visualstudio.com/manage/createpublisher)">Visual Studio Marketplace Publishing Portal</a>, right-click on your extension and select &quot;Remove&quot;.
 </div> 
-
 
 ### Step 3: Make the REST API Call 
 
@@ -561,8 +546,6 @@ Your final `hello-world2.html` is as follows:
 </html>
 ```
 
-<a name="manifest-updates-for-configuration"/>
-
 ### Step 5: Extension Manifest Updates
 
 In this step, we update the extension manifest to include an entry for our second widget.
@@ -627,8 +610,6 @@ Now, go to your team dashboard at http://dev.azure.com/{yourOrganization}/{yourP
 Hover on the Edit button in the bottom right, and select the Add button. This should open the widget catalog where you find the widget you installed. 
 Choose your widget and select the 'Add' button to add it to your dashboard.
 
-<a name="part-3"/>
-
 ## Part 3: Hello World with Configuration
 
 In [Part 2](#part-2) of this guide, you saw how to create a widget that shows query information for a hard-coded query. 
@@ -684,7 +665,6 @@ Add the below HTML in <code>configuration.html</code>. We basically add the mand
         </body>
     </html>
 ```
-<a name="configurationJs"/>
 
 ### Step 2: JavaScript - Configuration
 
@@ -744,8 +724,6 @@ and use `WidgetConfigurationSave.Valid()` to save the user input..
 In this guide, we use JSON to serialize the user input into a string. You can choose any other way to serialize the user input to string. 
 It is accessible to the widget via the customSettings property of the `WidgetSettings` object.
 The widget has to deserialize this, which is covered in [Step 4](#reload-widget).
-
-<a name="previewUpdate"/>
 
 ### Step 3: JavaScript - Enable Live Preview
 
@@ -829,7 +807,6 @@ At the end, your `configuration.html` looks like this:
         </body>
     </html>
 ```
-<a name="reload-widget"/>
 
 ### Step 4: JavaScript - Implement Reload in The Widget
 


### PR DESCRIPTION
The current documentation of "Add a dashboard widget" has some formatting problems. 
For example:

![image](https://user-images.githubusercontent.com/8773147/62519769-728c3400-b856-11e9-9e25-9ec78fa58afe.png)

and this: (the markdown header was translated as is)

![image](https://user-images.githubusercontent.com/8773147/62519867-9d768800-b856-11e9-82db-eb582a79285b.png)

Looking at the markdown file, this was caused by unused `<a>` anchor everywhere. 
For example, in line 64: 
`<a name="step-1-files" />`

I have cleanup these anchors and remove some redundant empty lines. Please review.

cc @elbatk @vtbassmatt 