### PR TITLE
Update feed locator URL

### DIFF
--- a/docs/artifacts/concepts/best-practices.md
+++ b/docs/artifacts/concepts/best-practices.md
@@ -55,11 +55,11 @@ Add any internal sources as an Azure DevOps Services upstream.
 
 Find out more information about [upstream sources](upstream-sources.md) and [how to configure upstream sources](../how-to/set-up-upstream-sources.md).
 
-### Sources not in your organization should be added using the feed locator
+### Sources not in your organization but in the same AAD tenant should be added using the feed locator
 
 The feed locator uses the following syntax:
 
-`vsts-feeds://<organization>/<feed>@<view>`
+`azure-feed://<organization>/<feed>@<view>`
 
 ### Ensure that the order of the sources matches your desired package resolution order
 


### PR DESCRIPTION
The documentation at https://docs.microsoft.com/en-us/azure/devops/artifacts/how-to/set-up-upstream-sources?view=azure-devops indicates a different feed locator URL format than indicated here (a different protocol is referenced.)  This change updates this page to match the other page, and clarifies the header for that area.