### PR TITLE
Remove free load test minutes

### DIFF
--- a/docs/user-guide/plan-your-azure-devops-org-structure.md
+++ b/docs/user-guide/plan-your-azure-devops-org-structure.md
@@ -47,7 +47,6 @@ Each organization gets its own *free tier* of services (up to five users for eac
 * [Azure Boards](https://azure.microsoft.com/services/devops/boards/): Work item tracking and Kanban boards
 * [Azure Repos](https://azure.microsoft.com/services/devops/repos/): Unlimited private Git repos
 * [Azure Artifacts](https://azure.microsoft.com/services/devops/artifacts/): Package management
-* Load testing (20,000 VUMs per month)
 * Unlimited Stakeholders
   [!INCLUDE [free-tier](../_shared/free-tier.md)]
 


### PR DESCRIPTION
Since load testing is deprecated I don't think this should be mentioned in the docs anymore?