### PR TITLE
Remove '.' from $(Rev:r) token example

### DIFF
--- a/docs/pipelines/process/run-number.md
+++ b/docs/pipelines/process/run-number.md
@@ -17,7 +17,6 @@ monikerRange: '>= tfs-2015'
 
 ::: moniker range="<= tfs-2018"
 [!INCLUDE [temp](../_shared/concept-rename-note.md)]
-::: moniker-end
 
 You can customize how your pipeline runs are numbered.
 
@@ -82,7 +81,7 @@ The following table shows how each token is resolved based on the previous examp
 | `$(Hours)` | 21 |
 | `$(Minutes)` | 7 |
 | `$(Month)` | 8 |
-| `$(Rev:.r)` | 2 (The third run on this day will be 3, and so on.)<br /><br />Use **$(Rev:.r)** to ensure that every completed build has a unique name. When a build is completed, if nothing else in the build number has changed, the Rev integer value is incremented by one.<br /><br />If you want to show prefix zeros in the number, you can add additional **'r'** characters. For example, specify **$(rev:.rr)** if you want the Rev number to begin with 01, 02, and so on. |
+| `$(Rev:r)` | 2 (The third run on this day will be 3, and so on.)<br /><br />Use **$(Rev:r)** to ensure that every completed build has a unique name. When a build is completed, if nothing else in the build number has changed, the Rev integer value is incremented by one.<br /><br />If you want to show prefix zeros in the number, you can add additional **'r'** characters. For example, specify **$(rev:rr)** if you want the Rev number to begin with 01, 02, and so on. |
 | `$(Date:yyyyMMdd)` | 20090824<br /><br />You can specify other date formats such as **$(Date:MMddyy)** |
 | `$(Seconds)` | 3 |
 | `$(SourceBranchName)` | master |


### PR DESCRIPTION
Change instances of $(Rev:.r)/$(Rev:.rr) to $(Rev:r)/$(Rev:rr).  If you include the "." in the token, then the result is ".1" and ".01" respectively.  The examples in the text do not have the preceding dot, so the dot should not be included in the token.