### PR TITLE
Fixes typo env variable in .NET/NuGet section

### DIFF
--- a/docs/pipelines/caching/index.md
+++ b/docs/pipelines/caching/index.md
@@ -237,7 +237,7 @@ steps:
 
 ## .NET/NuGet
 
-If you use `PackageReferences` to manage NuGet dependencies directly within your project file and have a `packages.lock.json` file, you can enable caching by setting the `NPM_PACKAGES` environment variable to a path under `$(Pipeline.Workspace)` and caching this directory.
+If you use `PackageReferences` to manage NuGet dependencies directly within your project file and have a `packages.lock.json` file, you can enable caching by setting the `NUGET_PACKAGES` environment variable to a path under `$(Pipeline.Workspace)` and caching this directory.
 
 ### Example
 


### PR DESCRIPTION
In the description it reads NPM_PACKAGES instead of NUGET_PACKAGES like the in example