### PR TITLE
Fixed casing of allowed parameter values

### DIFF
--- a/docs/pipelines/tasks/_shared/yaml/AzureResourceGroupDeploymentV2.md
+++ b/docs/pipelines/tasks/_shared/yaml/AzureResourceGroupDeploymentV2.md
@@ -13,7 +13,7 @@
     #csmFile: # Required when  TemplateLocation == Linked Artifact
     #csmParametersFile: # Optional
     #overrideParameters: # Optional
-    #deploymentMode: 'Incremental' # Options: incremental, complete, validation
+    #deploymentMode: 'Incremental' # Options: Incremental, Complete, Validation
     #enableDeploymentPrerequisites: 'None' # Optional. Options: none, configureVMwithWinRM, configureVMWithDGAgent
     #teamServicesConnection: # Required when enableDeploymentPrerequisites == ConfigureVMWithDGAgent
     #teamProject: # Required when enableDeploymentPrerequisites == ConfigureVMWithDGAgent


### PR DESCRIPTION
The parameters for `deploymentMode `should all start with capital letters (otherwise an error occurs).