### PR TITLE
Fixing the yaml syntax which is currently being lost

### DIFF
--- a/docs/pipelines/tasks/utility/bash.md
+++ b/docs/pipelines/tasks/utility/bash.md
@@ -61,20 +61,19 @@ The Bash task also has a shortcut syntax in YAML:
 <td>A list of additional items to map into the process&#39;s environment. For example, secret variables are not automatically mapped. If you have a secret variable called <code>Foo</code>, you can map it in like this:<br/><br/>
 <pre><code class="lang-yaml">
 steps:
-
-- task: Bash@3
-  inputs:
-    targetType: 'inline'
-    script: echo $MYSECRET
-  env:
-    MySecret: $(Foo)
+  - task: Bash@3
+    inputs:
+      targetType: 'inline'
+      script: echo $MYSECRET
+    env:
+      MySecret: $(Foo)
 </code></pre>
 <br/><br/>This is equivalent to:<br/><br/>
 <pre><code class="lang-yaml">
 steps:
-- script: echo $MYSECRET
-  env:
-    MySecret: $(Foo)
+  - script: echo $MYSECRET
+    env:
+      MySecret: $(Foo)
 </code></pre>
 </td>
 </tr>


### PR DESCRIPTION
The first example is currently showing online as:
```
steps:

task: Bash@3
inputs:
targetType: 'inline'
script: echo $MYSECRET
env:
MySecret: $(Foo)
```