### PR TITLE
Made more clear on how to do operations using Git Credentials

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1637,9 +1637,9 @@ steps:
 - checkout: none
 ```
 
-# [Example](#tab/example)
-If you want to modify the current repository using Git Operations and/or load Git Submodules
-Note: Don't forget to give the proper permissions to "Project Collection Build Service Accounts" in the project security.
+> [!NOTE]
+> If you want to modify the current repository using git operations and/or load git submodules, make sure to give the proper permissions to user in the agent in the repository security.
+> "Project Collection Build Service Accounts" if you are running the agent in Local Service Account
 
 ```yaml
 steps:
@@ -1647,7 +1647,6 @@ steps:
   submodules: true
   persistCredentials: true
 ```
-
 
 # [Example](#tab/example)
 

--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1639,7 +1639,7 @@ steps:
 
 # [Example](#tab/example)
 If you want to modify the current repository using Git Operations and/or load Git Submodules
-Note: Dont forget to give the proper permissions to "Project Collection Build Service Accounts" in the project security.
+Note: Don't forget to give the proper permissions to "Project Collection Build Service Accounts" in the project security.
 
 ```yaml
 steps:

--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1638,6 +1638,18 @@ steps:
 ```
 
 # [Example](#tab/example)
+If you want to modify the current repository using Git Operations and/or load Git Submodules
+Note: Dont forget to give the proper permissions to "Project Collection Build Service Accounts" in the project security.
+
+```yaml
+steps:
+- checkout: self
+  submodules: true
+  persistCredentials: true
+```
+
+
+# [Example](#tab/example)
 
 ```yaml
 steps:


### PR DESCRIPTION
Made more clear on how to do operations using Git Credentials, generally the community doesn't read this part and starts using PATs or user:password in plain text - this made a lot of stack overflow posts..