### PR TITLE
Add section with .NET Core / Mono compatibility

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -147,7 +147,7 @@ The Microsoft-hosted XAML build controller is no longer supported. If you have a
 
   Note that this command does not select the Mono version beyond the Xamarin SDK. To manually select a Mono version, see instructions below.
 
-  In case you are using a non-standard version of Xcode for building your Xamarin.iOS or Xamarin.Mac apps, you should additionally execute this command line:
+  In case you are using a non-default version of Xcode for building your Xamarin.iOS or Xamarin.Mac apps, you should additionally execute this command line:
 
   `/bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${xcodeRoot};sudo xcode-select --switch ${xcodeRoot}/Contents/Developer"`
   
@@ -176,6 +176,10 @@ The Microsoft-hosted XAML build controller is no longer supported. If you have a
   echo "##vso[task.setvariable variable=PKG_CONFIG_PATH;]$MONOPREFIX/lib/pkgconfig:$MONOPREFIX/share/pkgconfig:$PKG_CONFIG_PATH"
   echo "##vso[task.setvariable variable=PATH;]$MONOPREFIX/bin:$PATH"
 ```
+
+#### .NET Core
+  .NET Core 2.2.105 is default on VM images but Mono version 6.0 or greater requires .NET Core 2.2.300+
+  If you use the Mono 6.0 or greater, you will have to override .NET Core version using [.NET Core Tool Installer task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops).
 
 ## Videos 
 > [!VIDEO https://www.youtube.com/embed/A8f_05lnfe0?start=0]


### PR DESCRIPTION
We have a bunch of customers who can't use Mono 6.0 due to incompatible .NET Core:
- [Hosted macOS image (Visual Studio for Mac 8.2) build errors](https://github.com/microsoft/azure-pipelines-image-generation/issues/1193)
- [Cannot build Xamarin.Android on the latest (6.0.0) SD](https://github.com/microsoft/azure-pipelines-image-generation/issues/1185)

We need to clarify docs