### PR TITLE
fix: MD046/code-block-style docs/reference/

### DIFF
--- a/docs/reference/add-features-manually.md
+++ b/docs/reference/add-features-manually.md
@@ -233,15 +233,12 @@ Bug Behavior
     <li>Add <code>Fixed and verified</code> as a Resolved Reason </li>
     </ul>
     </li>
-
     <li>CMMI Bug:
     <ul>
     <li> Add fields: <code>Size</code>, <code>Discipline</code>, <code>Original Work</code>, <code>Completed Work</code>, and <code>Value Area</code>   </li>
     <li>Add  <code>New</code> state and corresponding workflow transitions</li>
     </ul>
     </li>
-
-
     <li>Scrum Bug:<br/>    <ul>
     <li>Add fields: <code>Activity</code>, <code>Remaining Work</code>, <code>Priority</code>, and <code>Value Area</code></li>
     <li>Add rule to zero out <code>Remaining Work</code> when <code>State=Done</code></li>
@@ -300,15 +297,19 @@ To learn more about managing process templates, see, [Upload or download a proce
 
 1. Enter the ```witadmin importwitd``` command, substituting your data for the arguments that are shown.   
 
-   ```witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"```
+    ```
+    witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"
+    ```
 
-       For *CollectionURL* specify the URL of a project collection and for *ProjectName* specify the name of a project defined within the collection. You must specify the URL in the following format: ```http://ServerName:Port/VirtualDirectoryName/CollectionName```.  
+    For *CollectionURL* specify the URL of a project collection and for *ProjectName* specify the name of a project defined within the collection. You must specify the URL in the following format: ```http://ServerName:Port/VirtualDirectoryName/CollectionName```.  
 
-       For *DirectoryPath*, specify the path to the ```WorkItem Tracking/TypeDefinitions``` folder that holds the process template that you downloaded. The directory path must follow this structure: ```Drive:\TemplateFolder\WorkItem Tracking\TypeDefinitions```.
+    For *DirectoryPath*, specify the path to the ```WorkItem Tracking/TypeDefinitions``` folder that holds the process template that you downloaded. The directory path must follow this structure: ```Drive:\TemplateFolder\WorkItem Tracking\TypeDefinitions```.
 
-   For  example,  import the Feedback Request WIT:
+    For  example,  import the Feedback Request WIT:
 
-   ```witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection"/p:MyProject /f:"C:\MyTemplates\WorkItem Tracking\TypeDefinitions\FeedbackRequest.xml"``` 
+    ```
+    witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection"/p:MyProject /f:"C:\MyTemplates\WorkItem Tracking\TypeDefinitions\FeedbackRequest.xml"
+    ``` 
 
 Here's a checklist of WITs to import to support new features:   
 -   **Portfolio Backlogs**: Epic and Feature

--- a/docs/reference/add-modify-field.md
+++ b/docs/reference/add-modify-field.md
@@ -84,20 +84,19 @@ Use the following syntax to add a Boolean field within the **FIELDS** section of
 ::: moniker-end
 
 ::: moniker range=">= tfs-2017"
-> [!div class="tabbedCodeSnippets"]
-> ```XML
-> <FIELD name="Triage" refname="Fabrikam.Triage" type="Boolean" >
->    <DEFAULT from="value" value="False" />
->    <HELPTEXT>Triage work item</HELPTEXT>
-> </FIELD>
-> ```
+
+```XML
+<FIELD name="Triage" refname="Fabrikam.Triage" type="Boolean" >
+   <DEFAULT from="value" value="False" />
+   <HELPTEXT>Triage work item</HELPTEXT>
+</FIELD>
+```
 
 And then add the following syntax within the **FORM** section to have the field appear on the form. 
 
-> [!div class="tabbedCodeSnippets"]
-> ```XML
-> <Control Label="Triage" Type="FieldControl" FieldName="Fabrikam.Triage" /> 
-> ```
+```XML
+<Control Label="Triage" Type="FieldControl" FieldName="Fabrikam.Triage" />
+```
  
 The field will appear as a checkbox on the form. 
 ::: moniker-end
@@ -144,13 +143,12 @@ To add a custom field or add rules to a field, edit the WIT definition. You can 
 
 For example, with the following code snippet, you can enforce the rule that only members of the Management Team, a customer defined TFS group, can modify the Stack Rank field once a work item has been created.
 
-> [!div class="tabbedCodeSnippets"]
-> ```XML
-> <FIELD name="Stack Rank" refname="Microsoft.VSTS.Common.StackRank" type="Double" reportable="dimension">  
->    <FROZEN not="[project]\Management Team" />  
->    <HELPTEXT>Work first on items with lower-valued stack rank. Set in triage.</HELPTEXT>
-> </FIELD>  
-> ```
+```XML
+<FIELD name="Stack Rank" refname="Microsoft.VSTS.Common.StackRank" type="Double" reportable="dimension">  
+   <FROZEN not="[project]\Management Team" />  
+   <HELPTEXT>Work first on items with lower-valued stack rank. Set in triage.</HELPTEXT>
+</FIELD>  
+```
 
 You apply rules to accomplish the following actions:  
 
@@ -180,41 +178,40 @@ To add a custom field, edit the WIT definition to add a **FIELD** element within
 
    The following code specifies the custom field, Requestor, with a reference name of ```FabrikamFiber.MyTeam.Requestor``` and a pick list of allowed values, with the default value of Customer.
 
-   > [!div class="tabbedCodeSnippets"]
-   > ```XML
-   > <FIELD name="Requestor" refname="FabrikamFiber.MyTeam.Requestor" type="String" reportable="Dimension">
-   >    <ALLOWEDVALUES>
-   >       <LISTITEM value="Customer" />
-   >       <LISTITEM value="Executive Management" />
-   >       <LISTITEM value="Other" />
-   >       <LISTITEM value="Support" />
-   >       <LISTITEM value="Team" />
-   >       <LISTITEM value="Technicians" />
-   >       <DEFAULTVALUE value="Customer" />
-   >     </ALLOWEDVALUES>
-   > </FIELD>
-   > ```
-   > 
+   ```XML
+   <FIELD name="Requestor" refname="FabrikamFiber.MyTeam.Requestor" type="String" reportable="Dimension">
+      <ALLOWEDVALUES>
+         <LISTITEM value="Customer" />
+         <LISTITEM value="Executive Management" />
+         <LISTITEM value="Other" />
+         <LISTITEM value="Support" />
+         <LISTITEM value="Team" />
+         <LISTITEM value="Technicians" />
+         <DEFAULTVALUE value="Customer" />
+       </ALLOWEDVALUES>
+   </FIELD>
+   ```
+   
    > [!TIP]
    > Elements within the list always appear in alphanumeric order, regardless of how you enter them in the XML definition file. The Reference Name, or `refname`, is the programmatic name for the field. All other rules should refer to the `refname`. For more information, see [Naming restrictions and conventions](../organizations/settings/naming-restrictions.md#WorkItemFields). 
 
 3. Add the `Control` element within the `FORM` section so that the custom field appears on the form within the group of elements where you want it to appear.
 
    For example, the following code snippet adds the Requestor field to appear below the Reason field on the work item form.
-   > [!div class="tabbedCodeSnippets"]
-   > ```XML
-   > <Column PercentWidth="50">
-   >    <Group Label="Status">
-   >       <Column PercentWidth="100">
-   >          <Control FieldName="System.AssignedTo" Type="FieldControl" Label="Assi&amp;gned To:" LabelPosition="Left" />
-   >          <Control FieldName="System.State" Type="FieldControl" Label="&amp;State:" LabelPosition="Left" />
-   >          <Control FieldName="System.Reason" Type="FieldControl" Label="Reason:" LabelPosition="Left" ReadOnly="True" />
-   >          <Control FieldName="FabrikamFiber.MyTeam.Requestor" Type="FieldControl" Label="Requestor:" LabelPosition="Left" ReadOnly="True" />
-   >       </Column>
-   >    </Group>
-   > </Column>
-   > ```
-   > 
+
+   ```XML
+   <Column PercentWidth="50">
+      <Group Label="Status">
+         <Column PercentWidth="100">
+            <Control FieldName="System.AssignedTo" Type="FieldControl" Label="Assi&amp;gned To:" LabelPosition="Left" />
+            <Control FieldName="System.State" Type="FieldControl" Label="&amp;State:" LabelPosition="Left" />
+            <Control FieldName="System.Reason" Type="FieldControl" Label="Reason:" LabelPosition="Left" ReadOnly="True" />
+            <Control FieldName="FabrikamFiber.MyTeam.Requestor" Type="FieldControl" Label="Requestor:" LabelPosition="Left" ReadOnly="True" />
+         </Column>
+      </Group>
+   </Column>
+   ```
+   
    > [!TIP]
    > The schema definition for work tracking defines all child elements of the `FORM` element as camel case and all other elements as all capitalized. If you encounter errors when validating your type definition files, check the case structure of your elements. Also, the case structure of opening and closing tags must match according to the rules for XML syntax. For more information, see [Control XML element reference](xml/control-xml-element-reference.md).   
 
@@ -236,21 +233,19 @@ To modify the field label, change the value assigned to the ```Control``` elemen
 
 1. In the `FORM` and `Layout` sections, find the definition of the field you want to modify. This example modifies the label for the **Title** field:
 
-   > [!div class="tabbedCodeSnippets"]
-   > ```XML
-   > <Column PercentWidth="70">  
-   >    <Control Type="FieldControl" FieldName="System.Title" Label="Title" LabelPosition="Left" />  
-   > </Column>
-   > ```
+   ```XML
+   <Column PercentWidth="70">  
+      <Control Type="FieldControl" FieldName="System.Title" Label="Title" LabelPosition="Left" />  
+   </Column>
+   ```
 
 2. Change the label for the field so that the Portuguese branch office working on this particular project can read the name of the **Title** field when they work with the work item form. Include the Portuguese word for title (Titulo) in the Title field.
 
-   > [!div class="tabbedCodeSnippets"]
-   > ```XML
-   > <Column PercentWidth="70">  
-   >    <Control Type="FieldControl" FieldName="System.Title" Label="Title (Titulo):" LabelPosition="Left" />  
-   > </Column>
-   > ```
+   ```XML
+   <Column PercentWidth="70">  
+      <Control Type="FieldControl" FieldName="System.Title" Label="Title (Titulo):" LabelPosition="Left" />  
+   </Column>
+   ```
 
 3. Import the modified WIT definition.
 
@@ -281,10 +276,9 @@ To add a custom control to the new web form, see [WebLayout and Control elements
 
 You use **witadmin changefield** to change the attributes of an existing field. For example, the following command changes the friendly name defined for MyCompany.Type to Evaluation Method.  
 
-> [!div class="tabbedCodeSnippets"]
-> ```
-> witadmin changefield /collection:http://AdventureWorksServer:8080/tfs/DefaultCollection /n:MyCompany.Type /name:"Evaluation Method"
-> ```  
+```
+witadmin changefield /collection:http://AdventureWorksServer:8080/tfs/DefaultCollection /n:MyCompany.Type /name:"Evaluation Method"
+```  
 
 The following table summarizes the attributes you can change using [witadmin changefield](witadmin/manage-work-item-fields.md).
 
@@ -421,18 +415,22 @@ When you remove a field from a specific type of work item, that field is not rem
 
 2.  Verify the field is not in use. For example:
 
-        witadmin listfields /collection:http://AdventureWorksServer:8080/tfs/DefaultCollection /n:MyCompany.CustomContact
+    ```
+    witadmin listfields /collection:http://AdventureWorksServer:8080/tfs/DefaultCollection /n:MyCompany.CustomContact
 
-        Field: MyCompany.CustomContact
-        Name: Custom Contact
-        Type: String
-        Reportable As: dimension
-        Use: Not In Use
-        Indexed: False
+    Field: MyCompany.CustomContact
+    Name: Custom Contact
+    Type: String
+    Reportable As: dimension
+    Use: Not In Use
+    Indexed: False
+    ```
 
 3.  Delete the field. For example:
 
-        witadmin deletefield /collection:http://AdventureWorksServer:8080/tfs/DefaultCollection /n:MyCompany.CustomContact
+    ```
+    witadmin deletefield /collection:http://AdventureWorksServer:8080/tfs/DefaultCollection /n:MyCompany.CustomContact
+    ```
 
 4.  If the deleted field was reportable, [rebuild the data warehouse to purge the old field and its values](../Report/admin/rebuild-data-warehouse-and-cube.md).
 

--- a/docs/reference/add-modify-wit.md
+++ b/docs/reference/add-modify-wit.md
@@ -104,7 +104,9 @@ You add fields and field rules to the **FIELDS** section. For the field to appea
 
 For example, to add the work item ID to a form, specify the following XML syntax within the `FORM` section.
 
-    <Control FieldName="System.ID" Type="FieldControl" Label="ID" LabelPosition="Left" />
+```xml
+<Control FieldName="System.ID" Type="FieldControl" Label="ID" LabelPosition="Left" />
+```
 
 To learn more about defining fields, see [Add or modify a field](add-modify-field.md).
 
@@ -237,20 +239,24 @@ If you want to restrict creation of a specific WIT to a group of users, there ar
 
 -   Add [a field rule to the workflow](xml/apply-rule-work-item-field.md) for the System.CreatedBy field to effectively restrict a group of users from creating a work item of a specific type. As the following example shows, the user who creates the work item must belong to the `Allowed Group` in order to save the work item.
 
-        <TRANSITION from=" " to="New">
-           <FIELDS>
-              <FIELD refname="System.CreatedBy">
-                <VALIDUSER for="Allowed Group" not="Disallowed Group" />
-              </FIELD>
-           </FIELDS>
-        </TRANSITION> 
+    ```xml
+    <TRANSITION from=" " to="New">
+        <FIELDS>
+            <FIELD refname="System.CreatedBy">
+            <VALIDUSER for="Allowed Group" not="Disallowed Group" />
+            </FIELD>
+        </FIELDS>
+    </TRANSITION> 
+    ```
 
 <a id="delete-wit">  </a>
 ## Delete a WIT (On-premises XML) 
 
 To prevent team members from using a specific WIT to create a work item, you can remove it from the project. When you use **witadmin destroywitd**, you permanently remove all work items that were created using that WIT as well as the WIT itself. For example, if your team doesn't use "Impediment", you can delete the WIT labeled "Impediment" from the Fabrikam Web Site project.
 
-    witadmin destroywitd /collection:"http://FabrikamPrime:8080/tfs/DefaultCollection" /p:"Fabrikam Web Site" /n:"Impediment" 
+```
+witadmin destroywitd /collection:"http://FabrikamPrime:8080/tfs/DefaultCollection" /p:"Fabrikam Web Site" /n:"Impediment" 
+```
 
 When you delete a WIT that belongs to a category, you must update the categories definition for the project to reflect the new name. For more information, see [Import, export, and manage work item types](witadmin/witadmin-import-export-manage-wits.md) and [Import and export categories](witadmin/witadmin-import-export-categories.md).
 

--- a/docs/reference/add-portfolio-backlogs.md
+++ b/docs/reference/add-portfolio-backlogs.md
@@ -223,29 +223,35 @@ If you're updating a project that connects to an on-premises TFS, you'll use the
 
 1. Enter the ```witadmin``` command, substituting your data for the arguments that are shown. For example, to import a WIT:   
 
-   ```witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"```
+    ```
+    witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"
+    ```
 
-       For *CollectionURL* specify the URL of a project collection and for *ProjectName* specify the name of a project defined within the collection. You must specify the URL in the following format: ```http://ServerName:Port/VirtualDirectoryName/CollectionName```.  
+    For *CollectionURL* specify the URL of a project collection and for *ProjectName* specify the name of a project defined within the collection. You must specify the URL in the following format: ```http://ServerName:Port/VirtualDirectoryName/CollectionName```.  
 
-       For *DirectoryPath*, specify the path to the ```WorkItem Tracking/TypeDefinitions``` folder that holds the process template that you downloaded. The directory path must follow this structure: ```Drive:\TemplateFolder\WorkItem Tracking\TypeDefinitions```.
+    For *DirectoryPath*, specify the path to the ```WorkItem Tracking/TypeDefinitions``` folder that holds the process template that you downloaded. The directory path must follow this structure: ```Drive:\TemplateFolder\WorkItem Tracking\TypeDefinitions```.
 
    For  example,  import the ServiceApp WIT:
 
-   ```witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection"/p:MyProject /f:"DirectoryPath/ServiceApp.xml"``` 
+    ```
+    witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection"/p:MyProject /f:"DirectoryPath/ServiceApp.xml"
+    ``` 
 
 Use these commands to export and import categories and process configuration: 
 
-    witadmin exportwitd /collection:CollectionURL /p:"ProjectName" /n:TypeName /f:"DirectoryPath\WITDefinitionFile.xml"
+```
+witadmin exportwitd /collection:CollectionURL /p:"ProjectName" /n:TypeName /f:"DirectoryPath\WITDefinitionFile.xml"
 
-    witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"
+witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"
 
-    witadmin exportcategories /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/categories.xml"
+witadmin exportcategories /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/categories.xml"
 
-    witadmin importcategories /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/categories.xml"
+witadmin importcategories /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/categories.xml"
 
-    witadmin exportprocessconfig /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/ProcessConfiguration.xml"
+witadmin exportprocessconfig /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/ProcessConfiguration.xml"
 
-    witadmin importprocessconfig /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/ProcessConfiguration.xml"
+witadmin importprocessconfig /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/ProcessConfiguration.xml"
+```
 
 
 ## Related articles  

--- a/docs/reference/add-wits-to-backlogs-and-boards.md
+++ b/docs/reference/add-wits-to-backlogs-and-boards.md
@@ -474,24 +474,30 @@ Use the **witadmin** commands to import and export definition files. For details
 
 1. Enter the ```witadmin``` command, substituting your data for the arguments that are shown. For example, to import a WIT:   
 
-   ```witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"```
+    ```
+    witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"
+    ```
 
-       For *CollectionURL* specify the URL of a project collection and for *ProjectName* specify the name of a project defined within the collection. You must specify the URL in the following format: ```http://ServerName:Port/VirtualDirectoryName/CollectionName```.  
+    For *CollectionURL* specify the URL of a project collection and for *ProjectName* specify the name of a project defined within the collection. You must specify the URL in the following format: ```http://ServerName:Port/VirtualDirectoryName/CollectionName```.  
 
-       For *DirectoryPath*, specify the path to the ```WorkItem Tracking/TypeDefinitions``` folder that holds the process template that you downloaded. The directory path must follow this structure: ```Drive:\TemplateFolder\WorkItem Tracking\TypeDefinitions```.
+    For *DirectoryPath*, specify the path to the ```WorkItem Tracking/TypeDefinitions``` folder that holds the process template that you downloaded. The directory path must follow this structure: ```Drive:\TemplateFolder\WorkItem Tracking\TypeDefinitions```.
 
-   For  example,  import the ServiceApp WIT:
+    For  example,  import the ServiceApp WIT:
 
-   ```witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection"/p:MyProject /f:"DirectoryPath/ServiceApp.xml"``` 
+    ```
+    witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection"/p:MyProject /f:"DirectoryPath/ServiceApp.xml"
+    ``` 
 
 Use these commands to export and import WITs, categories, and process configuration: 
 
-	witadmin exportwitd /collection:CollectionURL /p:"ProjectName" /n:TypeName /f:"DirectoryPath\WITDefinitionFile.xml"  
-	witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"  
-	witadmin exportcategories /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/categories.xml"  
-	witadmin importcategories /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/categories.xml"   
-	witadmin exportprocessconfig /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/ProcessConfiguration.xml"  
-	witadmin importprocessconfig /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/ProcessConfiguration.xml"  
+```
+witadmin exportwitd /collection:CollectionURL /p:"ProjectName" /n:TypeName /f:"DirectoryPath\WITDefinitionFile.xml"  
+witadmin importwitd /collection:CollectionURL /p:"ProjectName" /f:"DirectoryPath\WITDefinitionFile.xml"  
+witadmin exportcategories /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/categories.xml"  
+witadmin importcategories /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/categories.xml"   
+witadmin exportprocessconfig /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/ProcessConfiguration.xml"  
+witadmin importprocessconfig /collection:"CollectionURL" /p:"ProjectName" /f:"DirectoryPath/ProcessConfiguration.xml"  
+```
 
 ## Related articles  
 We've just shown how to add another WIT to your backlogs or boards. However, if you want to add another WIT to act as a portfolio backlog, see [Add portfolio backlogs](add-portfolio-backlogs.md).

--- a/docs/reference/customize-wit-form.md
+++ b/docs/reference/customize-wit-form.md
@@ -84,7 +84,9 @@ See the following topics to make the indicated customizations:
 
 2. Export the WIT definition file where you want to modify or add a field. Specify the name of the WIT and a name for the file.  
 
-       witadmin exportwitd /collection:CollectionURL /p:ProjectName /n:TypeName /f:"DirectoryPath/FileName.xml"  
+    ```
+    witadmin exportwitd /collection:CollectionURL /p:ProjectName /n:TypeName /f:"DirectoryPath/FileName.xml"  
+    ```
 
    An example of a <em>CollectionURL</em> for an organization is https://dev.azure.com/*OrganizationName*.
 
@@ -92,7 +94,9 @@ See the following topics to make the indicated customizations:
 
 4. Import the WIT definition file.  
 
-       witadmin importwitd /collection:CollectionURL /p:ProjectName /f:"DirectoryPath/FileName.xml"  
+    ```
+    witadmin importwitd /collection:CollectionURL /p:ProjectName /f:"DirectoryPath/FileName.xml"  
+    ```
 
 5. Open either the web portal to view the changes. If the client is already open, refresh the page. 
 

--- a/docs/reference/use-team-fields-instead-area-paths.md
+++ b/docs/reference/use-team-fields-instead-area-paths.md
@@ -43,33 +43,37 @@ When you customize your project to support team fields, the Team field tab appea
 
 1. If you aren't a member of the **Project Administrators** group, [get those permissions](../organizations/security/set-project-collection-level-permissions.md).
 
-[!INCLUDE [temp](../_shared/witadmin-run-tool-example.md)]
+    [!INCLUDE [temp](../_shared/witadmin-run-tool-example.md)]
 
 1. Export the global list for the project collection.
 
-       witadmin exportgloballist /collection:"http://MyServer:8080/tfs/DefaultCollection" /f:Directory/globallist.xml"
+    ```
+    witadmin exportgloballist /collection:"http://MyServer:8080/tfs/DefaultCollection" /f:Directory/globallist.xml"
+    ```
 
-   Add the global list definition for your team. Include a value you'll want to use for items not yet assigned to a team. If your global list is empty, simply copy the following code, paste into the XML file, and modify to support your team labels.
+    Add the global list definition for your team. Include a value you'll want to use for items not yet assigned to a team. If your global list is empty, simply copy the following code, paste into the XML file, and modify to support your team labels.
 
 
-```XML
-<?xml version="1.0" encoding="utf-8"?>
-<gl:GLOBALLISTS xmlns:gl="http://schemas.microsoft.com/VisualStudio/2005/workitemtracking/globallists">
-   <GLOBALLIST name="Teams">
-    <LISTITEM value="Unassigned"/>
-    <LISTITEM value="Team A"/>
-    <LISTITEM value="Team B"/>
-    <LISTITEM value="Team C"/>
-    <LISTITEM value="Team D"/>
-   </GLOBALLIST>
-</gl:GLOBALLISTS>
-```
+    ```XML
+    <?xml version="1.0" encoding="utf-8"?>
+    <gl:GLOBALLISTS xmlns:gl="http://schemas.microsoft.com/VisualStudio/2005/workitemtracking/globallists">
+       <GLOBALLIST name="Teams">
+        <LISTITEM value="Unassigned"/>
+        <LISTITEM value="Team A"/>
+        <LISTITEM value="Team B"/>
+        <LISTITEM value="Team C"/>
+        <LISTITEM value="Team D"/>
+       </GLOBALLIST>
+    </gl:GLOBALLISTS>
+    ```
 
 1. Import the global list definition.
 
-       witadmin importgloballist /collection:"http://MyServer:8080/tfs/DefaultCollection" /f:Directory/globallist.xml"
+    ```
+    witadmin importgloballist /collection:"http://MyServer:8080/tfs/DefaultCollection" /f:Directory/globallist.xml"
+    ```
 
-   Note that global lists are defined for all projects within a project collection.
+    Note that global lists are defined for all projects within a project collection.
 
 
 
@@ -80,74 +84,82 @@ Add a custom team field to all work item types (WITs) that are included in the F
 
 1.  Export the work item type definitions. For Scrum, export the type definitions for the feature, product backlog item, bug, and task.
 
-        witadmin exportwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /n:"Product Backlog Item" /f:Directory/pbi.xml
-        witadmin exportwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /n:Bug /f:Directory/bug.xml
-        witadmin exportwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /n:Task /f:Directory/task.xml 
-        witadmin exportwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /n:"Test Plan" /f:Directory/TestPlan.xml
+    ```
+    witadmin exportwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /n:"Product Backlog Item" /f:Directory/pbi.xml
+    witadmin exportwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /n:Bug /f:Directory/bug.xml
+    witadmin exportwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /n:Task /f:Directory/task.xml 
+    witadmin exportwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /n:"Test Plan" /f:Directory/TestPlan.xml
+    ```
 
 2.  For each type, add a custom Team field that references the global list.
 
-        > [!div class="tabbedCodeSnippets"]
+    > [!div class="tabbedCodeSnippets"]
 		```XML
-        <FIELDS>
-        . . . 
-           <FIELD name="Team" refname="MyCompany.Team" type="String" reportable="dimension">
-              <HELPTEXT>Name of the team that will do the work.</HELPTEXT>
-                <ALLOWEXISTINGVALUE />
-                  <ALLOWEDVALUES >
-                    <GLOBALLIST name="Teams" />
-                </ALLOWEDVALUES >
-                <DEFAULT from="value" value="Unassigned" />
-              </FIELD>
-        . . . 
-        </FIELDS>
-        ```
+    <FIELDS>
+    . . . 
+        <FIELD name="Team" refname="MyCompany.Team" type="String" reportable="dimension">
+          <HELPTEXT>Name of the team that will do the work.</HELPTEXT>
+            <ALLOWEXISTINGVALUE />
+              <ALLOWEDVALUES >
+                <GLOBALLIST name="Teams" />
+            </ALLOWEDVALUES >
+            <DEFAULT from="value" value="Unassigned" />
+          </FIELD>
+    . . . 
+    </FIELDS>
+    ```
 
     > [!TIP]  
     >Name your custom field to distinguish it from other system fields. Do not use "System" as a prefix for `refname`. And, keep the `name` and `refname` labels to 128 characters and 70, respectively.
 
 3.  Add the **Team** field to the [Layout section](xml/layout-xml-element-reference.md) of the work item form. You'll also need to edit the [**WebLayout** section](xml/weblayout-xml-elements.md) of the WIT definition. 
 
-        > [!div class="tabbedCodeSnippets"]
+    > [!div class="tabbedCodeSnippets"]
 		```XML
-        <FORM>
-        . . . 
-          <Group Label="Status">
-              <Column PercentWidth="100">
-                 <Control FieldName="MyCompany.Team" Type="FieldControl" Label="Team" LabelPosition="Left" EmptyText="&lt;None&gt;" />
-                 <Control Type="FieldControl" FieldName="System.AssignedTo" Label="Assi&amp;gned to:" LabelPosition="Left" />
-                 <Control FieldName="System.State" Type="FieldControl" Label="Stat&amp;e" LabelPosition="Left" />
-                 <Control FieldName="System.Reason" Type="FieldControl" Label="Reason" LabelPosition="Left" ReadOnly="True" />
-              </Column>
-          </Group>
-        . . . 
-        </FORM>
-        ```
+    <FORM>
+    . . . 
+      <Group Label="Status">
+          <Column PercentWidth="100">
+              <Control FieldName="MyCompany.Team" Type="FieldControl" Label="Team" LabelPosition="Left" EmptyText="&lt;None&gt;" />
+              <Control Type="FieldControl" FieldName="System.AssignedTo" Label="Assi&amp;gned to:" LabelPosition="Left" />
+              <Control FieldName="System.State" Type="FieldControl" Label="Stat&amp;e" LabelPosition="Left" />
+              <Control FieldName="System.Reason" Type="FieldControl" Label="Reason" LabelPosition="Left" ReadOnly="True" />
+          </Column>
+      </Group>
+    . . . 
+    </FORM>
+    ```
 
     Optionally, move the Area Path field to appear before or after the Iteration Path.
 
 4.  Import the updated type definitions.
 
-        witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/pbi.xml
-        witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/bug.xml
-        witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/task.xml
-        witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/TestPlan.xml
+    ```
+    witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/pbi.xml
+    witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/bug.xml
+    witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/task.xml
+    witadmin importwitd /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/TestPlan.xml
+    ```
 
 <a id="processconfig">  </a>  
 ### 3. Change process configuration to reference the team field
 
 1.  Export the ProcessConfiguration XML definition.
 
-        witadmin exportprocessconfig /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/ProcessConfiguration.xml
+    ```
+    witadmin exportprocessconfig /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/ProcessConfiguration.xml
+    ```
 
 2.  Replace `System.AreaPath` for the field used to specify `type="Team"`.
 
-        <TypeField refname="MyCompany.Team" type="Team" />
+    ```xml
+    <TypeField refname="MyCompany.Team" type="Team" />
+    ```
 
 3.  (Optional) Add the Team field to the quick add panel for the backlog page.  
   
 
-```XML
+  ```XML
   <RequirementBacklog category="Microsoft.RequirementCategory" parent="Microsoft.FeatureCategory" pluralName="Stories" singularName="User Story">
     <AddPanel>
       <Fields>
@@ -156,11 +168,13 @@ Add a custom team field to all work item types (WITs) that are included in the F
       </Fields>
     </AddPanel> 
   . . .
-```
+  ```
 
 4. Import the definition file.
 
-       witadmin importprocessconfig /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/ProcessConfiguration.xml
+    ```
+    witadmin importprocessconfig /collection:"http://MyServer:8080/tfs/DefaultCollection" /p:MyProject /f:Directory/ProcessConfiguration.xml
+    ```
 
 <a id="config-teamfield">  </a>  
 ### 4. Configure the Team field for each team

--- a/docs/reference/xml/apply-rule-work-item-field.md
+++ b/docs/reference/xml/apply-rule-work-item-field.md
@@ -264,25 +264,31 @@ You can make a pick list or assign value rule to apply or not apply to a group o
 
     Use **for** to apply a rule to a group. This example requires any user in the Junior Analysts group to complete the Second Approver field.
 
-        <FIELD name="Second Approver">
+    ```xml
+    <FIELD name="Second Approver">
         <REQUIRED for="Example1\Junior Analysts"/>
-        </FIELD>
+    </FIELD>
+    ```
 
 -   **Restrict modification of a field to a group of users:**
 
     Use **not** to exclude a group from a rule. This example defines the Triage Description field as read-only for everyone except those users in the Triage Committee group.
 
-        <FIELD name="Triage Description">
+    ```xml
+    <FIELD name="Triage Description">
         <READONLY not="[Project]\Triage Committee" />
-        </FIELD>
+    </FIELD>
+    ```
 
 -   **Make a field required for some users and not for others:**
 
     Use a combination of **for** and **not** to simultaneously apply a rule to some and not for others. This example defines Severity as a required field for users in the Project Members group, but not for those in the Project Admins group.
 
-        <FIELD name="Severity">
+    ```xml
+    <FIELD name="Severity">
         <REQUIRED for="[Project]\Project Members" not="[Global]\Project Admins"/>
-        </FIELD>
+    </FIELD>
+    ```
 
     If a user is in both groups, the "for" statement would be enforced, and the field would be required.
 
@@ -318,29 +324,37 @@ Person-name fields can accept values that reference both users and groups. Field
 
     Use [GLOBAL] to reference a collection-scoped TFS group, such as the Project Collection Administrators group or a Windows group you add to a collection. For example:
 
-        <FIELD name="Title">
+    ```xml
+    <FIELD name="Title">
         <READONLY for="[GLOBAL]\Project Collection Valid Users"/>
-        </FIELD>
+    </FIELD>
+    ```
 
 -   **Scope to a server instance &mdash;[Team Foundation]:**
 
     Use the [Team Foundation] token to reference a server-scoped TFS group, such as a built-in group or a Windows group you add to a server-level group. For example:
 
-        <FIELD name="Title">
+    ```xml
+    <FIELD name="Title">
         <READONLY for="[Team Foundation]\Team Foundation Valid Users"/>
-        </FIELD>
+    </FIELD>
+    ```
 
 -   **Specify a domain qualified account or group:**
 
     Domain-qualified account name, such as the one shown in the following example, can be used to reference a domain user or group. Note that some rules only support groups and do not support referencing domain users.
 
-        <LISTITEM value="FABRIKAM\Christie Church's Direct Reports"/>
+    ```xml
+    <LISTITEM value="FABRIKAM\Christie Church's Direct Reports"/>
+    ```
 
 All users and groups must be qualified by one of these tokens. For example, the following XML isn't valid because it doesn't qualify the specified group with a valid token.
 
-    <FIELD name="Title">
+```xml
+<FIELD name="Title">
     <READONLY for="Dev Team"/>
-    </FIELD>
+</FIELD>
+```
 
 To learn more about built-in groups, see [Permissions and groups](../../organizations/security/permissions.md) 
 

--- a/docs/reference/xml/weblayout-xml-elements.md
+++ b/docs/reference/xml/weblayout-xml-elements.md
@@ -603,74 +603,72 @@ Once the extensions have been installed, you add the <b>Contribution</b> element
 
 When you export the XML definition, it will contain a comment section that lists the installed extensions, their IDs, and any required inputs. For example: 
 
-> [!div class="tabbedCodeSnippets"]
-> ```XML
-> <!--**********************Work Item Extensions**********************
-> Extension:
->     Name: color-control-dev
->     Id: mariamclaughlin.color-control-dev
->     Control contribution:
->         Id: mariamclaughlin.color-control-dev.color-control-contribution
->         Description: 
->         Inputs:
->             Id: FieldName
->             Description: The field associated with the control.
->             Type: Field
->             IsRequired: true
->             Id: Labels
->             Description: The list of values to select from.
->             Type: String
->             IsRequired: false
->             Id: Colors
->             Description: The field associated with the control.
->             Type: String
->             IsRequired: false  
-> Extension:
->     Name: vsts-workitem-recentlyviewed
->     Id: mmanela.vsts-workitem-recentlyviewed  
->     Group contribution:
->         Id: mmanela.vsts-workitem-recentlyviewed.recently-viewed-form-group
->         Description: Recently viewed work item form group  
-> Extension:
->     Name: vsts-extensions-multi-values-control
->     Id: ms-devlabs.vsts-extensions-multi-values-control   
->     Control contribution:
->         Id: ms-devlabs.vsts-extensions-multi-values-control.multi-values-form-control
->         Description: Multi Values Selection Control.
->         Inputs:
->             Id: FieldName
->             Description: The field associated with the control.
->             Type: Field
->             IsRequired: true
->             Id: Values
->             Description: The list of values to select from.
->             Type: String
->             IsRequired: false
-> Extension:
->     Name: vsts-extension-workitem-activities
->     Id: ms-devlabs.vsts-extension-workitem-activities   
-> Extension:
->     Name: vsts-uservoice-ui
->     Id: ms-devlabs.vsts-uservoice-ui   
->     Group contribution:
->         Id: ms-devlabs.vsts-uservoice-ui.vsts-uservoice-ui-wi-group
->         Description: Shows User Voice details on the work item form
-> --> 
-> ```
+```XML
+<!--**********************Work Item Extensions**********************
+Extension:
+    Name: color-control-dev
+    Id: mariamclaughlin.color-control-dev
+    Control contribution:
+        Id: mariamclaughlin.color-control-dev.color-control-contribution
+        Description: 
+        Inputs:
+            Id: FieldName
+            Description: The field associated with the control.
+            Type: Field
+            IsRequired: true
+            Id: Labels
+            Description: The list of values to select from.
+            Type: String
+            IsRequired: false
+            Id: Colors
+            Description: The field associated with the control.
+            Type: String
+            IsRequired: false  
+Extension:
+    Name: vsts-workitem-recentlyviewed
+    Id: mmanela.vsts-workitem-recentlyviewed  
+    Group contribution:
+        Id: mmanela.vsts-workitem-recentlyviewed.recently-viewed-form-group
+        Description: Recently viewed work item form group  
+Extension:
+    Name: vsts-extensions-multi-values-control
+    Id: ms-devlabs.vsts-extensions-multi-values-control   
+    Control contribution:
+        Id: ms-devlabs.vsts-extensions-multi-values-control.multi-values-form-control
+        Description: Multi Values Selection Control.
+        Inputs:
+            Id: FieldName
+            Description: The field associated with the control.
+            Type: Field
+            IsRequired: true
+            Id: Values
+            Description: The list of values to select from.
+            Type: String
+            IsRequired: false
+Extension:
+    Name: vsts-extension-workitem-activities
+    Id: ms-devlabs.vsts-extension-workitem-activities   
+Extension:
+    Name: vsts-uservoice-ui
+    Id: ms-devlabs.vsts-uservoice-ui   
+    Group contribution:
+        Id: ms-devlabs.vsts-uservoice-ui.vsts-uservoice-ui-wi-group
+        Description: Shows User Voice details on the work item form
+-->
+```
 
 
 Given the above example, you can add the following code snippet to your work item type definition to turn on the user voice group ```vsts-uservoice-ui``` extension by specifying the extension Id:
 
-> [!div class="tabbedCodeSnippets"]
-> ```XML
-> <WebLayout>
-> ... 
->  <Extensions>
->      <Extension Id="ms-devlabs.vsts-uservoice-ui" /> 
->  </Extensions> 
-> ...
-> </WebLayout> 
-> ```
+```XML
+<WebLayout>
+... 
+ <Extensions>
+     <Extension Id="ms-devlabs.vsts-uservoice-ui" />
+ </Extensions>
+...
+</WebLayout> 
+```
 
 Upon import of the updated WIT definition, the group extension will automatically appear on your work item form.
 


### PR DESCRIPTION

Ensure consistent fended code block style.
The implicit indent fences sometimes accidentally swallow content not intended as code blocks.