### PR TITLE
fix: MD046/code-block-style docs/extend/

### DIFF
--- a/docs/extend/develop/ui-controls/menubaro.md
+++ b/docs/extend/develop/ui-controls/menubaro.md
@@ -22,18 +22,11 @@ This page shows different samples about the menubar control.
 ## Basic menubar
 This sample shows the basic usage of the toolbar. Notice how `text` is added to the separators which becomes a group text for sub menus.
 
-<ul class="nav nav-tabs" data-tabs="tabs">
-<li class="active"><a data-toggle="tab" href="#typescript_basic_menubar">TypeScript</a></li>
-<li><a data-toggle="tab" href="#javascript_basic_menubar">JavaScript</a></li>
-</ul>
-
-<div class="tab-content">
-  <div id="typescript_basic_menubar" class="tab-pane fade in active">
-<pre><code class="lang-typescript">
-import Controls = require(&quot;VSS/Controls&quot;);
-import Menus = require(&quot;VSS/Controls/Menus&quot;);
+```typescript
+import Controls = require("VSS/Controls");
+import Menus = require("VSS/Controls/Menus");
   
-var container = $(&quot;.sample-container&quot;);
+var container = $(".sample-container");
 
 var menuItems: Menus.IMenuItemSpec[] = [
   { id: "file", text: "File", icon: "icon-pause", childItems: [
@@ -63,12 +56,11 @@ var menubarOptions = {
 };
 
 var menubar = Controls.create<Menus.MenuBar, any>(Menus.MenuBar, container, menubarOptions);
-</code></pre>
-  </div>
-  <div id="javascript_basic_menubar" class="tab-pane fade">
-<pre><code class="lang-javascript">
-VSS.require([&quot;VSS/Controls&quot;, &quot;VSS/Controls/Menus&quot;], function(Controls, Menus) {
-  var container = $(&quot;#sample-container&quot;);
+```
+
+```javascript
+VSS.require(["VSS/Controls", "VSS/Controls/Menus"], function(Controls, Menus) {
+  var container = $("#sample-container");
 
 
   var menuItems = [
@@ -103,9 +95,7 @@ VSS.require([&quot;VSS/Controls&quot;, &quot;VSS/Controls/Menus&quot;], function
  });
   
 VSS.notifyLoadSucceeded();
- </code></pre>
-  </div>
-</div>
+```
 
 <div align="center" style="padding-top:15px">
 <img alt="Basic menubar extension gif" src="_img/basic_menubar.gif" /> 
@@ -115,16 +105,9 @@ VSS.notifyLoadSucceeded();
 ## Actions of the menubar
 This sample uses `executeAction` delegate to react menubar commands.
 
-<ul class="nav nav-tabs" data-tabs="tabs">
-<li class="active"><a data-toggle="tab" href="#typescript_action_menubar">TypeScript</a></li>
-<li><a data-toggle="tab" href="#javascript_action_menubar">JavaScript</a></li>
-</ul>
-
-<div class="tab-content">
-  <div id="typescript_action_menubar" class="tab-pane fade in active">
-<pre><code class="lang-typescript">
-import Controls = require(&quot;VSS/Controls&quot;);
-import Menus = require(&quot;VSS/Controls/Menus&quot;);
+```typescript
+import Controls = require("VSS/Controls");
+import Menus = require("VSS/Controls/Menus");
 
 var container = $(".sample-container");
 
@@ -158,12 +141,12 @@ var menubarOptions = {
 };
 
 Controls.create<Menus.MenuBar, any>(Menus.MenuBar, container, menubarOptions);
-</code></pre>
-  </div>
-  <div id="javascript_action_menubar" class="tab-pane fade">
-<pre><code class="lang-javascript">
-VSS.require([&quot;VSS/Controls&quot;, &quot;VSS/Controls/Menus&quot;], function(Controls, Menus) {
-  var container = $(&quot;#sample-container&quot;);
+```
+
+
+```javascript
+VSS.require(["VSS/Controls", "VSS/Controls/Menus"], function(Controls, Menus) {
+  var container = $("#sample-container");
 
 
   var menuItems = [
@@ -200,9 +183,7 @@ VSS.require([&quot;VSS/Controls&quot;, &quot;VSS/Controls/Menus&quot;], function
  });
   
 VSS.notifyLoadSucceeded();
- </code></pre>
-  </div>
-</div>
+```
 
 <div align="center" style="padding-top:15px">
 <img alt="Action menubar extension gif" src="_img/action_menubar.gif" /> 
@@ -215,16 +196,9 @@ This sample shows how the menu items can be enabled/disabled.
 <button id="btnToggle">Toggle Enabled/Disabled</button>
 ```
 
-<ul class="nav nav-tabs" data-tabs="tabs">
-<li class="active"><a data-toggle="tab" href="#typescript_toggle_menubar">TypeScript</a></li>
-<li><a data-toggle="tab" href="#javascript_toggle_menubar">JavaScript</a></li>
-</ul>
-
-<div class="tab-content">
-  <div id="typescript_toggle_menubar" class="tab-pane fade in active">
-<pre><code class="lang-typescript">
-import Controls = require(&quot;VSS/Controls&quot;);
-import Menus = require(&quot;VSS/Controls/Menus&quot;);
+```typescript
+import Controls = require("VSS/Controls");
+import Menus = require("VSS/Controls/Menus");
 
 var container = $(".sample-container");
 
@@ -244,12 +218,11 @@ $("#btnToggle").click(function (e) {
     { id: "settings", disabled: !(settingsItem.getCommandState() & Menus.MenuItemState.Disabled) },
   ]);
 });
-</code></pre>
-  </div>
-  <div id="javascript_toggle_menubar" class="tab-pane fade">
-<pre><code class="lang-javascript">
-VSS.require([&quot;VSS/Controls&quot;, &quot;VSS/Controls/Menus&quot;], function(Controls, Menus) {
-  var container = $(&quot;#sample-container&quot;);
+```
+
+```javascript
+VSS.require(["VSS/Controls", "VSS/Controls/Menus"], function(Controls, Menus) {
+  var container = $("#sample-container");
 
 
   var menuItems = [
@@ -279,9 +252,7 @@ VSS.require([&quot;VSS/Controls&quot;, &quot;VSS/Controls/Menus&quot;], function
 });
   
 VSS.notifyLoadSucceeded();
- </code></pre>
-  </div>
-</div>
+```
 
 <div align="center" style="padding-top:15px">
 <img alt="Toggle menubar extension gif" src="_img/toggle_menubar.gif" /> 
@@ -293,16 +264,11 @@ This sample shows how the menu items can be made visible/hidden.
 ```html
 <button id="btnToggle">Toggle Show/Hide</button>
 ```
-<ul class="nav nav-tabs" data-tabs="tabs">
-<li class="active"><a data-toggle="tab" href="#typescript_hide_menubar">TypeScript</a></li>
-<li><a data-toggle="tab" href="#javascript_hide_menubar">JavaScript</a></li>
-</ul>
 
-<div class="tab-content">
-  <div id="typescript_hide_menubar" class="tab-pane fade in active">
-<pre><code class="lang-typescript">
-import Controls = require(&quot;VSS/Controls&quot;);
-import Menus = require(&quot;VSS/Controls/Menus&quot;);
+
+```typescript
+import Controls = require("VSS/Controls");
+import Menus = require("VSS/Controls/Menus");
 
 var container = $(".sample-container");
 
@@ -322,12 +288,11 @@ $("#btnToggle").click(function (e) {
     { id: "help", hidden: !(helpItem.getCommandState() & Menus.MenuItemState.Hidden) }
   ]);
 });
-</code></pre>
-  </div>
-  <div id="javascript_hide_menubar" class="tab-pane fade">
-<pre><code class="lang-javascript">
-VSS.require([&quot;VSS/Controls&quot;, &quot;VSS/Controls/Menus&quot;], function(Controls, Menus) {
-  var container = $(&quot;#sample-container&quot;);
+```
+
+```javascript
+VSS.require(["VSS/Controls", "VSS/Controls/Menus"], function(Controls, Menus) {
+  var container = $("#sample-container");
 
 
  var menuItems = [
@@ -349,9 +314,7 @@ VSS.require([&quot;VSS/Controls&quot;, &quot;VSS/Controls/Menus&quot;], function
 });
   
 VSS.notifyLoadSucceeded();
- </code></pre>
-  </div>
-</div>
+```
 
 <div align="center" style="padding-top:15px">
 <img alt="Hide menubar extension gif" src="_img/hide_menubar.gif" /> 

--- a/docs/extend/get-started/node.md
+++ b/docs/extend/get-started/node.md
@@ -276,8 +276,8 @@ In order to debug the extension using Visual Studio or Browser Developer Tools a
 This tells Azure DevOps Services to load the extension from your local web server instance (e.g. IISExpress in Visual Studio).
 After changing manifest you need to deploy and install this debugging extension only once.
 
-    >[!NOTE]
-    >You have to run local web server in SSL mode, because Azure DevOps Services demands that web page is served from a secure source otherwise you obtain an error in browser console during the extension IFRAME loading.
+> [!NOTE]
+> You have to run local web server in SSL mode, because Azure DevOps Services demands that web page is served from a secure source otherwise you obtain an error in browser console during the extension IFRAME loading.
 
 
 ## Next steps


### PR DESCRIPTION

Ensure consistent fended code block style.
The implicit indent fences sometimes accidentally swallow content not intended as code blocks.