### PR TITLE
fix: MD046/code-block-style docs/organizations/security/

### DIFF
--- a/docs/organizations/security/access-levels.md
+++ b/docs/organizations/security/access-levels.md
@@ -218,21 +218,6 @@ read wiki pages. </td>
 <td><img src="/azure/devops/_img/icons/checkmark.png" alt="checkmark"/></td>
 <td><img src="/azure/devops/_img/icons/checkmark.png" alt="checkmark"/></td>
 </tr>
-<!---
-<tr>
-<td align="left"><strong>Microsoft published Azure DevOps Extensions</strong></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>
-
-![checkmark](/azure/devops/_img/icons/checkmark.png)
-
-</td>
-</tr>
--->
-
-
 </tbody>
 </table>
 


### PR DESCRIPTION

Ensure consistent fended code block style.
The implicit indent fences sometimes accidentally swallow content not intended as code blocks.