### PR TITLE
fix: MD046/code-block-style docs/boards/

### DIFF
--- a/docs/boards/backlogs/add-link.md
+++ b/docs/boards/backlogs/add-link.md
@@ -247,9 +247,8 @@ From the Add link dialog you can open a secondary dialog to help you choose one 
 
      Only those work items defined for the selected project and specified work item type are listed. To sort on a column field, choose the column title. 
 
-    <!--- You can change the display of the work items that are listed by using one of the following user interface controls:  
-
-        To expand or collapse a tree view list, choose the + or signs.    
+    <!-- You can change the display of the work items that are listed by using one of the following user interface controls:  
+      To expand or collapse a tree view list, choose the + or signs.    
       To resize a column, point your cursor at the edge of a column header and drag it to a new location.    
       To sort on a column field, choose the column title.    
       To move a column field, choose the column title and drag to another location. -->  

--- a/docs/boards/backlogs/add-work-items.md
+++ b/docs/boards/backlogs/add-work-items.md
@@ -51,11 +51,11 @@ Choose a **Boards** page&mdash;such as **Work Items**, **Boards**, or **Backlogs
 > ![Work, add artifact](../../project/navigation/_img/add-artifact/add-work-item-query-vert.png)
 
 
-> [!NOTE]  
->Depending on the process chosen when the project was created&mdash;[Agile](../work-items/guidance/agile-process.md), [Basic](../get-started/plan-track-work.md), [Scrum](../work-items/guidance/scrum-process.md), 
+> [!NOTE]
+> Depending on the process chosen when the project was created&mdash;[Agile](../work-items/guidance/agile-process.md), [Basic](../get-started/plan-track-work.md), [Scrum](../work-items/guidance/scrum-process.md),
 or [CMMI](../work-items/guidance/cmmi-process.md)&mdash;the types of work items you can create will differ. For example, backlog items may be called user stories (Agile), issues (Basic) product backlog items (Scrum), or requirements (CMMI). All four are similar: they describe the customer value to deliver and the work to be performed.
 >
-> For an overview of all default processes, see [Choose a process](../work-items/guidance/choose-process.md). Note that the Basic process requires Azure DevOps Server 2019.1 or later version. 
+> For an overview of all default processes, see [Choose a process](../work-items/guidance/choose-process.md). Note that the Basic process requires Azure DevOps Server 2019.1 or later version.
 
 ::: moniker-end
 

--- a/docs/boards/queries/add-tags-to-work-items.md
+++ b/docs/boards/queries/add-tags-to-work-items.md
@@ -7,7 +7,8 @@ ms.technology: devops-agile
 ms.prod: devops
 ms.assetid: 79A08F31-BB8A-48BD-AD17-477EE0B76BC7
 ms.manager: jillfra
-ms.author: kaelliauthor: KathrynEE
+ms.author: kaelli
+author: KathrynEE
 ms.topic: conceptual
 monikerRange: '>= tfs-2013'
 ms.date: 09/26/2019
@@ -215,7 +216,9 @@ While no hard limit exists, creating more than 100K tags for a project collectio
 
 You can't assign more than 100 tags to a work item or you'll receive the following message:  
 
-	TF401243: Failed to save work item because too many new tags were added to the work item.
+```
+TF401243: Failed to save work item because too many new tags were added to the work item.
+```
 
 Simply save the work item with the tags (100 or less) that you've added, and then you can add more tags. 
 

--- a/docs/boards/queries/planning-ranking-priorities.md
+++ b/docs/boards/queries/planning-ranking-priorities.md
@@ -182,10 +182,14 @@ To add the field to the form, add the Stack Rank field to a work item type ([for
 ::: moniker range=">= tfs-2015 <= tfs-2018"  
 To add the field to the form, [modify the WIT XML definition to add the following control element](../../reference/add-modify-wit.md):
 
-    `<Control FieldName="Microsoft.VSTS.Common.StackRank" Type="FieldControl" Label="Stack Rank" LabelPosition="Left" />`
+```xml
+<Control FieldName="Microsoft.VSTS.Common.StackRank" Type="FieldControl" Label="Stack Rank" LabelPosition="Left" />
+```
 
-    or, for Scrum
+or, for Scrum
 
-    `<Control FieldName="Microsoft.VSTS.Common.BacklogPriority" Type="FieldControl" Label="Stack Rank" LabelPosition="Left" />`
+```xml
+<Control FieldName="Microsoft.VSTS.Common.BacklogPriority" Type="FieldControl" Label="Stack Rank" LabelPosition="Left" />
+```
 
 ::: moniker-end  

--- a/docs/boards/queries/titles-ids-descriptions.md
+++ b/docs/boards/queries/titles-ids-descriptions.md
@@ -176,7 +176,6 @@ System Info<sup>1</sup>
   </td>
   <td>
     <p>Information about the software and system configuration that is relevant to the bug, code review, or feedback. </p>
-
     <p>Reference name=Microsoft.VSTS.TCM.SystemInfo, Data type=HTML</p>
   </td>
   <td>Bug, Code Review Request, Feedback Request<br/>  </td>

--- a/docs/boards/work-items/guidance/cmmi-process-workflow.md
+++ b/docs/boards/work-items/guidance/cmmi-process-workflow.md
@@ -189,7 +189,6 @@ Use the following guidance and that provided for [fields used in common across w
         </li>
       </ul>
       <p>
-        
       </p>
     </td>
   </tr>


### PR DESCRIPTION

Ensure consistent fended code block style.
The implicit indent fences sometimes accidentally swallow content not intended as code blocks.