### PR TITLE
fix: MD046/code-block-style docs/repos/

### DIFF
--- a/docs/repos/git/git-dates.md
+++ b/docs/repos/git/git-dates.md
@@ -28,38 +28,46 @@ If you want to see commit date, you can use one of the many command line options
 
 Let's look at a brief example to see these concepts in practice. First we will create a normal commit:
 
-    git init
-    echo test > file.txt
-    git add *
-    git commit -m "A normal commit message"
+```
+git init
+echo test > file.txt
+git add *
+git commit -m "A normal commit message"
+```
 
 Now let's amend our commit with a different message:
 
-    echo again > file.txt
-    git add *
-    git commit --amend -m "An amended commit"
-    
+```
+echo again > file.txt
+git add *
+git commit --amend -m "An amended commit"
+```
+
 If we look at our regular log history we would see something like the following:
 
-    git log
-    
-    commit 17232459f0ae25adeff21c9e21742ba22b7f3499
-    Author: Ross Brodbeck <robrodbe@microsoft.com>
-    Date:   Thu Feb 25 19:38:54 2016 -0500
+```
+git log
 
-        An amended commit
+commit 17232459f0ae25adeff21c9e21742ba22b7f3499
+Author: Ross Brodbeck <robrodbe@microsoft.com>
+Date:   Thu Feb 25 19:38:54 2016 -0500
+
+    An amended commit
+```
 
 Now let's view the same commit with the author date:
 
-    git log --pretty=fuller
-    
-    commit 17232459f0ae25adeff21c9e21742ba22b7f3499
-    Author:     Ross Brodbeck <robrodbe@microsoft.com>
-    AuthorDate: Thu Feb 25 19:38:54 2016 -0500
-    Commit:     Ross Brodbeck <robrodbe@microsoft.com>
-    CommitDate: Thu Feb 25 19:39:36 2016 -0500
+```
+git log --pretty=fuller
 
-        An amended commit
+commit 17232459f0ae25adeff21c9e21742ba22b7f3499
+Author:     Ross Brodbeck <robrodbe@microsoft.com>
+AuthorDate: Thu Feb 25 19:38:54 2016 -0500
+Commit:     Ross Brodbeck <robrodbe@microsoft.com>
+CommitDate: Thu Feb 25 19:39:36 2016 -0500
+
+    An amended commit
+```
 
 Note the (slight) difference between the author date and commit date above.
 The author date is my original, unedited, commit time. The commit date is the time at which I ran the `--amend` command.

--- a/docs/repos/git/merging.md
+++ b/docs/repos/git/merging.md
@@ -78,32 +78,32 @@ Resolve merge conflicts on the command line:
 
 1. (Optional) Before performing any `pull` or `merge`, make sure that your repo is clean with `git status`. 
 
-    <pre style="color:white;background-color:black;font-family:Consolas,Courier,monospace;padding:10px">
-    &gt; git status
-    <font color="#b5bd68">On branch myfeature
-    nothing to commit, working directory clean</font>
-    </pre>
+    ```
+    > git status
+    On branch myfeature
+    nothing to commit, working directory clean
+    ```
 
 2. Perform your `pull` or `merge`. Use `git status` to see exactly which files did not merge properly.
 
-    <pre style="color:white;background-color:black;font-family:Consolas,Courier,monospace;padding:10px">
-    &gt; git pull origin <font color="#b5bd68">myfeature </font>   
+    ```
+    > git pull origin myfeature
 
-    <font color="#b5bd68">Auto-merging serverboot.js
+    Auto-merging serverboot.js
     CONFLICT (content): Merge conflict in serverboot.js
-    Automatic merge failed; fix conflicts and then commit the result</font>
-    </pre>
+    Automatic merge failed; fix conflicts and then commit the result
+    ```
 
 3. (Optional) Check the commit logs to find the commits that conflict with your own using `git log --merge`. 
 
-    <pre style="color:white;background-color:black;font-family:Consolas,Courier,monospace;padding:10px">
-    &gt; git log --merge
-    <font color="#b5bd68">commit fac422e78f105ccb44b50a00fc82d6ea89b15513
+    ```
+    > git log --merge
+    commit fac422e78f105ccb44b50a00fc82d6ea89b15513
     Merge: 9b28b1e 1dd2603
     Author: Francis Totten frank@fabrikam.com
 
-        merging new api endpoint</font>
-    </pre>   
+        merging new api endpoint
+    ```
 
 4. Update the conflicted files listed in `git status`. Git adds markers to files that have conflicts. These markers look like:   
 
@@ -121,10 +121,10 @@ Resolve merge conflicts on the command line:
 6. Resolve file deleting conflicts with `git add` (keep the file) or `git rm` (remove the file).
 7. If performing a merge (such as in a `pull`), commit the changes. If performing a rebase, use `git rebase --continue` to proceed.
 
-    <pre style="color:white;background-color:black;font-family:Consolas,Courier,monospace;padding:10px">
-    &gt; git add <font color="#b5bd68">serverboot.js</font>
-    &gt; git commit -m <font color="#b5bd68">"Resolved both new api endpoints"</font>
-    </pre>
+    ```
+    > git add serverboot.js
+    > git commit -m "Resolved both new api endpoints"
+    ```
 
 * * *
 ## Next steps

--- a/docs/repos/git/require-branch-folders.md
+++ b/docs/repos/git/require-branch-folders.md
@@ -50,21 +50,31 @@ Each command is preceded with an explanation of what it's doing. If you don't ha
 
 First, block the Create Branch permission at the repository root for the project's contributors.
 
-    tf git permission /deny:CreateBranch /group:[FabrikamProject]\Contributors /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo
+```
+tf git permission /deny:CreateBranch /group:[FabrikamProject]\Contributors /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo
+```
 
 Then, allow contributors to create branches under `features` and `users`.
 
-    tf git permission /allow:CreateBranch /group:[FabrikamProject]\Contributors /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo /branch:features
+```
+tf git permission /allow:CreateBranch /group:[FabrikamProject]\Contributors /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo /branch:features
+```
 
-    tf git permission /allow:CreateBranch /group:[FabrikamProject]\Contributors /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo /branch:users
+```
+tf git permission /allow:CreateBranch /group:[FabrikamProject]\Contributors /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo /branch:users
+```
 
 Allow administrators to create branches under `releases`.
 
-    tf git permission /allow:CreateBranch /group:"[FabrikamProject]\Project Administrators" /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo /branch:releases
+```
+tf git permission /allow:CreateBranch /group:"[FabrikamProject]\Project Administrators" /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo /branch:releases
+```
 
 Finally, allow administrators to create a branch called `master` (in case it ever gets deleted accidentally.
 
-    tf git permission /allow:CreateBranch /group:"[FabrikamProject]\Project Administrators" /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo /branch:master
+```
+tf git permission /allow:CreateBranch /group:"[FabrikamProject]\Project Administrators" /collection:https://dev.azure.com/fabrikam-fiber/ /teamproject:FabrikamProject /repository:FabrikamRepo /branch:master
+```
 
 >[!NOTE]
 >For more information, see [tf git permission](../../repos/tfvc/git-permission-command.md). You can also access help for these commands from the command line by running `tf git /?` and `tf git permission /?`.
@@ -93,14 +103,18 @@ Finally, allow administrators to create a branch called `master` (in case it eve
 #### [Command Line](#tab/command-line/)
 First, make sure you have the latest set of branches:
 
-    cd {your_repo}
-    git fetch
+```
+cd {your_repo}
+git fetch
+```
 
 Then, repeat these commands for each branch you want to migrate:
 
-    git branch -m {old_branch_name} {new_branch_name}
-    git push origin {new_branch_name}
-    git push origin --delete {old_branch_name}
+```
+git branch -m {old_branch_name} {new_branch_name}
+git push origin {new_branch_name}
+git push origin --delete {old_branch_name}
+```
 
 >[!NOTE]
 >Any custom permissions or branch policies you had set up will not be migrated.

--- a/docs/repos/tfvc/add-command.md
+++ b/docs/repos/tfvc/add-command.md
@@ -25,8 +25,10 @@ Adds files and folders to version control.
 
 **Requirements:** See [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf add itemspec [/lock:(none|checkin|checkout)] [/encoding:filetype] 
-    [/noprompt] [/recursive] [/noignore] [/login:username,[password]] 
+```
+tf add itemspec [/lock:(none|checkin|checkout)] [/encoding:filetype] 
+[/noprompt] [/recursive] [/noignore] [/login:username,[password]] 
+```
 
 ## Parameters
 
@@ -48,21 +50,31 @@ In all the following examples, assume that `$/SiteApp/Main/` is mapped to `c:\\c
 
 New files in a [local workspace](decide-between-using-local-server-workspace.md) are automatically detected. You can promote these newly detected files to your pending changes.
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf add
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf add
+```
 
 Adds the latest versions of all items (except those that are [ignored](add-files-server.md#tfignore)) in a local workspace.
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf add /noignore
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf add /noignore
+```
 
 Adds the latest versions of all items in a local workspace.
 
 ### Add individual items
-    c:\code\SiteApp\Main>tf add program1.cs program2.c
+
+```
+c:\code\SiteApp\Main>tf add program1.cs program2.c
+```
 
 Adds the files program1.cs and program2.c.
 
 ### Recursively add all items of a specific type
-    c:\code\SiteApp\Main>tf add *.cs /recursive
+
+```
+c:\code\SiteApp\Main>tf add *.cs /recursive
+```
 
 Adds all C\# code files (.cs) in the current directory and any subdirectories.
 

--- a/docs/repos/tfvc/add-files-server.md
+++ b/docs/repos/tfvc/add-files-server.md
@@ -204,21 +204,23 @@ The following rules apply to a .tfignore file:
 
 ### .tfignore file example
 
-    ######################################
-    # Ignore .cpp files in the ProjA sub-folder and all its subfolders
-    ProjA\*.cpp
-    #
-    # Ignore .txt files in this folder
-    \*.txt
-    #
-    # Ignore .xml files in this folder and all its sub-folders
-    *.xml
-    #
-    # Ignore all files in the Temp sub-folder
-    \Temp
-    #
-    # Do not ignore .dll files in this folder nor in any of its sub-folders
-    !*.dll
+```
+######################################
+# Ignore .cpp files in the ProjA sub-folder and all its subfolders
+ProjA\*.cpp
+#
+# Ignore .txt files in this folder
+\*.txt
+#
+# Ignore .xml files in this folder and all its sub-folders
+*.xml
+#
+# Ignore all files in the Temp sub-folder
+\Temp
+#
+# Do not ignore .dll files in this folder nor in any of its sub-folders
+!*.dll
+```
 
 ### Create and use a .tfignore file
 

--- a/docs/repos/tfvc/associate-file-type-file-comparison-tool.md
+++ b/docs/repos/tfvc/associate-file-type-file-comparison-tool.md
@@ -43,7 +43,9 @@ To perform this procedure, you must be a member of the **Administrators** or **U
 4.  In the **Operation** list, choose **Compare**.  
 5.  In the **Command** box, either type the path and name of your tool, or choose the ellipses (**...**) to locate and specify it. The result should resemble the following example:
 
-        C:\Program Files\OtherDiff\otherdiff.exe
+    ```
+    C:\Program Files\OtherDiff\otherdiff.exe
+    ```
 
 6.  In the **Arguments** box, type any arguments that your tool requires:  
     -   **%1**: The path to the source file.  
@@ -58,19 +60,25 @@ To perform this procedure, you must be a member of the **Administrators** or **U
     **Use white space to delimit the arguments.**  
     For example, you might specify the following syntax to compare two files:
 
-        %1 %2
+    ```
+    %1 %2
+    ```
 
     **Use quotation marks to pass white space or quotation marks to the tool.**  
     If an argument includes one or more spaces, you must enclose it in quotation marks (""). If an argument contains one or more quotation marks, you must add another quotation mark immediately after any quotation mark in the argument. For example, you could specify the following argument:
 
-        "This "" embeds a double quote"
+    ```
+    "This "" embeds a double quote"
+    ```
 
     **Pass labels ("friendly names") to the tool.**  
     If your tool supports displaying a label (a "friendly name"), such as **c:\\workspace\\test\\MyWindow.xaml.cs;C5 (server) 4/26/2010 1:32 PM**, you can include the `%6` and `%7` tokens to pass label values to the tool. If you do not specify these tokens, the tool may show names of temporary files, which can be difficult to read.
 
     For example, you might specify the following syntax to display labels.
 
-        %1 /title1=%6 %2 /title2=%7
+    ```
+    %1 /title1=%6 %2 /title2=%7
+    ```
 
 	>**Note:**  
 	>This capability is not related to version-control labels, which you apply to specific versions of items in version control, as described in [Use labels to take a snapshot of your files](use-labels-take-snapshot-your-files.md).

--- a/docs/repos/tfvc/branch-command.md
+++ b/docs/repos/tfvc/branch-command.md
@@ -27,7 +27,10 @@ The **branch** command copies an item or set of items, including metadata and ve
 
 To use the **branch** command, you must have the **Read** permission for the source item and the **Check out** and **Merge** permissions for the target folder set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf branch olditem newitem [/version:versionspec] [/noget] [/lock:(none|checkin|checkout)] [/noprompt] [/silent] [/checkin] [/comment:("comment"|@commentfile)] [/author:authorname] [/login:username, [password]] [/recursive]
+```
+tf branch olditem newitem [/version:versionspec] [/noget] [/lock:(none|checkin|checkout)] [/noprompt] [/silent] [/checkin] [/comment:("comment"|@commentfile)] [/author:authorname] [/login:username, [password]] [/recursive]
+```
+
 ## Parameters
 
 |     **Argument**      |                                                                                                                                                                                      **Description**                                                                                                                                                                                       |
@@ -83,27 +86,39 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example creates a branch file that contains the latest workspace version of 314.cs, names it "314\_branch", and saves it to the current directory on disk and also to the Team Foundation version control server folder to which it maps.
 
-    c:\projects>tf branch 314.cs 314_branch
+```
+c:\projects>tf branch 314.cs 314_branch
+```
 
 The following example copies all the files without pending edits in the workspace version of 314.cs from its current Team Foundation version control server folder into the testdata Team Foundation version control server folder and from the current directory on disk to the working folder that maps to the testdata Team Foundation version control server folder.
 
-    c:\projects>tf branch C:\314.cs $/testdata
+```
+c:\projects>tf branch C:\314.cs $/testdata
+```
 
 The following example copies all the files without pending edits in the current workspace version of the testfiles folder and the files it contains for all items from its current Team Foundation version control server folder into the testfiles\_branch Team Foundation version control server folder and from c:\\testfiles into the local folder that maps to the testfiles\_branch Team Foundation version control server folder.
 
-    c:\projects>tf branch C:\testfiles $/testfiles_branch
+```
+c:\projects>tf branch C:\testfiles $/testfiles_branch
+```
 
 The following example creates a branch of 314.cs as it existed in changeset \#4 for the file. In the working folder on disk, as in the Team Foundation version control server, a branch file titled csharp\_branch is created.
 
-    c:\projects>tf branch C:\314.cs;C4 csharp_branch
+```
+c:\projects>tf branch C:\314.cs;C4 csharp_branch
+```
 
 The following example creates a new branch of 314.cs as it was on 12/12/03. In the working folder on disk as in the Team Foundation version control server, a branch file titled 314\_branch is created.
 
-    c:\projects>tf branch 314.cs;D12/12/03 314_branch
+```
+c:\projects>tf branch 314.cs;D12/12/03 314_branch
+```
 
 The following example branches the version of 314.cs to which the "Beta1" label was applied, names it "Beta1branch," and saves it to the current directory on disk in addition to the Team Foundation version control server folder to which the current directory maps.
 
-    c:\projects>tf branch 314.cs;LBeta1 314_Beta1branch
+```
+c:\projects>tf branch 314.cs;LBeta1 314_Beta1branch
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/branches-command.md
+++ b/docs/repos/tfvc/branches-command.md
@@ -24,7 +24,9 @@ Displays the history of a branch for a specified file or folder.
 
 To use the **branches** command, your **Read** permission must be set to **Allow** for the item and any branches to view their history. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf branches itemspec [/version:versionspec] [/collection:TeamProjectCollectionUrl] [/login:username,[password]]
+```
+tf branches itemspec [/version:versionspec] [/collection:TeamProjectCollectionUrl] [/login:username,[password]]
+```
 
 ## Parameters<table>
 <thead>
@@ -84,23 +86,31 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 
 The following example displays branch history for the version-controlled file C:\\314.cs.
 
-    c:\projects>tf branches 314.cs
+```
+c:\projects>tf branches 314.cs
+```
 
 The following example displays branch history for the header.h item in the Team Foundation version control server.
 
-    c:\projects>tf branches $/applications/header.h
+```
+c:\projects>tf branches $/applications/header.h
+```
 
 The following example displays the branch history of the folder $/rel30/math.
 
-    c:\projects>tf branches $/rel30/math/
+```
+c:\projects>tf branches $/rel30/math/
+```
 
 The following example displays the branch history for WindowsApplication13-branch. The results indicate the history for the specified branch by using angle brackets.
 
-    D:\projects\ws1>tf branches WindowsApplication13-branch
-    $/jun16-1/WindowsApplication13
-    >>      $/jun16-1/WindowsApplication13-branch   Branched from version 3 <<
-                    $/jun16-1/WindowsApplication13-branch-prime     Branched from version 5
-            $/jun16-1/WindowsApplication13-branch2  Branched from version 3
+```
+D:\projects\ws1>tf branches WindowsApplication13-branch
+$/jun16-1/WindowsApplication13
+>>      $/jun16-1/WindowsApplication13-branch   Branched from version 3 <<
+                $/jun16-1/WindowsApplication13-branch-prime     Branched from version 5
+        $/jun16-1/WindowsApplication13-branch2  Branched from version 3
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/changeset-command.md
+++ b/docs/repos/tfvc/changeset-command.md
@@ -24,9 +24,11 @@ Displays information about and lets you change the attributes, such as comments 
 
 To use the **changeset** command you must have the **Read** permission set to **Allow** for any files or folders in the changeset for which you wish to display full information. The only users who can modify the notes and comments that are associated with a changeset are the users who created the changeset or a user who has the Revise other user's changes global permission. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf changeset [/comment:("comment"|@commentfile)] 
-    [/notes:("NoteFieldName"="NoteFieldValue"|@notefile)] [/noprompt][/collection:TeamProjectCollectionUrl]] 
-    [changesetnumber | /latest][/login:username,[password]]
+```
+tf changeset [/comment:("comment"|@commentfile)] 
+[/notes:("NoteFieldName"="NoteFieldValue"|@notefile)] [/noprompt][/collection:TeamProjectCollectionUrl]] 
+[changesetnumber | /latest][/login:username,[password]]
+```
 
 ## Parameters
 
@@ -64,62 +66,80 @@ The following example Displays detailed information about changeset 8675309 in a
 
 After you press ENTER, the **Details for Changeset** *\<changeset number\>* **- Source Files** dialog box appears. Click **Save** to associate the comment with the changeset.
 
-    c:\projects>tf changeset /comment:"This is a new comment." 8675309
+```
+c:\projects>tf changeset /comment:"This is a new comment." 8675309
+```
 
 The following example provides two check-in notes to associate with the changeset.
 
-    c:\projects>tf changeset /notes:reviewer=Jo;Security = checked 8675309
+```
+c:\projects>tf changeset /notes:reviewer=Jo;Security = checked 8675309
+```
 
 The following example provides two check-in notes that include spaces in the values and names to associate with the changeset.
 
-    c:\projects>tf changeset /notes:"Code Reviewer"="John Smith";"Security Reviewer"="Chen Yang" 8675309
+```
+c:\projects>tf changeset /notes:"Code Reviewer"="John Smith";"Security Reviewer"="Chen Yang" 8675309
+```
 
 The following example associates the check-in notes included in the file notes.txt with the changeset 8675309.
 
-    c:\projects>tf changeset /notes:@notes.txt 8675309
+```
+c:\projects>tf changeset /notes:@notes.txt 8675309
+```
 
 Where the notes.txt can be in following format:
 
 ```
 field1=value1;
 ```
+
 ```
 field2=value that
 ```
+
 ```
 spans multiple
 ```
+
 ```
 lines;
 ```
+
 ```
 field3 = value3;
 ```
 
-The following example replaces the existing comment for changeset 8675309 and displays information about the changeset in the Command Prompt window. The example does not start the **Changeset **dialog box.
+The following example replaces the existing comment for changeset 8675309 and displays information about the changeset in the Command Prompt window. The example does not start the **Changeset** dialog box.
 
-    c:\projects>tf changeset /comment:"This is an automatically generated comment." /noprompt 8675309
+```
+c:\projects>tf changeset /comment:"This is an automatically generated comment." /noprompt 8675309
+```
 
 The following example displays non-editable information about changeset 8675309 in the Command Prompt window.
 
-    c:\projects>tf changeset 8675309 /noprompt
+```
+c:\projects>tf changeset 8675309 /noprompt
+```
 
 Sample output:
 
-    Changeset: 8675309
-    User: DOMAIN\JohnG
-    Date: 01/21/2004 21:03:45
-    Comment:  This check-in fixes issues in several features.  I also refactored some items in buf.c into a new file named bif.c because buf.c was too hard to parse.
-    Items:
-       $/baz/proj/bif.c           Added
-       $/baz/proj/buf.c          Modified, Renamed
-    Work Items:
-       34527     The "Access Denied" message is not descriptive enough.
-       35628     The UI flickers when I press the '8', 'y', 'Ctrl', and 'End' buttons at the same time.
-    Check-in Notes:
-       Code Reviewer:  ShellM
-       Performance Reviewer: ShellM
-       Security Reviewer: ShellM
+```
+Changeset: 8675309
+User: DOMAIN\JohnG
+Date: 01/21/2004 21:03:45
+Comment:  This check-in fixes issues in several features.  I also refactored some items in buf.c into a new file named bif.c because buf.c was too hard to parse.
+Items:
+    $/baz/proj/bif.c           Added
+    $/baz/proj/buf.c          Modified, Renamed
+Work Items:
+    34527     The "Access Denied" message is not descriptive enough.
+    35628     The UI flickers when I press the '8', 'y', 'Ctrl', and 'End' buttons at the same time.
+Check-in Notes:
+    Code Reviewer:  ShellM
+    Performance Reviewer: ShellM
+    Security Reviewer: ShellM
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/checkin-command.md
+++ b/docs/repos/tfvc/checkin-command.md
@@ -24,11 +24,15 @@ Almost every change that you make to the files on your dev machine is stored in 
 
 **Requirements**: See [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf checkin [/author:author name] [/comment:("comment"|@comment file)] 
-    [/noprompt] [/notes:("Note Name"="note text"|@notefile)] 
-    [/override:(reason|@reasonfile)] [/recursive] [/saved] [/validate] [itemspec] [/bypass] [/force] [/noautoresolve]  [/login:username,[password]] [/new]
+```
+tf checkin [/author:author name] [/comment:("comment"|@comment file)] 
+[/noprompt] [/notes:("Note Name"="note text"|@notefile)] 
+[/override:(reason|@reasonfile)] [/recursive] [/saved] [/validate] [itemspec] [/bypass] [/force] [/noautoresolve]  [/login:username,[password]] [/new]
+```
 
-    tf checkin /shelveset:shelvesetname[;shelvesetowner] [/bypass] [/noprompt] [/login:username,[password]] [/collection:TeamProjectCollectionUrl][/author:author name] [/force]
+```
+tf checkin /shelveset:shelvesetname[;shelvesetowner] [/bypass] [/noprompt] [/login:username,[password]] [/collection:TeamProjectCollectionUrl][/author:author name] [/force]
+```
 
 ## Parameters
 
@@ -158,19 +162,25 @@ Almost every change that you make to the files on your dev machine is stored in 
 
 ### Check in all pending changes in the current workspace
 
-    c:\code\SiteApp\Main>tf checkin
+```
+c:\code\SiteApp\Main>tf checkin
+```
 
 Displays the **Check In** dialog box, which displays all pending changes in the current workspace. You can use the **Check In** dialog box to select or clear the pending changes you want to check in, add a comment, associate work items, and perform other tasks and then choose the **Check In** button when you are ready to proceed.
 
 ### Check in all pending changes with a comment
 
-    c:\code\SiteApp\Main>tf checkin /comment:"Re-implemented Pi calculator"
+```
+c:\code\SiteApp\Main>tf checkin /comment:"Re-implemented Pi calculator"
+```
 
 Checks in all pending changes in the current workspace and provides a comment to help your teammates understand the purpose of your changes.
 
 ### Check in a change to a single item without using the Check In dialog box
 
-    c:\code\SiteApp\Main>tf checkin program.cs /noprompt
+```
+c:\code\SiteApp\Main>tf checkin program.cs /noprompt
+```
 
 Checks in your pending changes to program.cs. The **Check In** dialog box is not displayed, and if any conflicts block the check in, the system does not display the conflicts window.
 

--- a/docs/repos/tfvc/checkout-or-edit-command.md
+++ b/docs/repos/tfvc/checkout-or-edit-command.md
@@ -22,7 +22,9 @@ Checks out a file and changes its pending change status to Edit. You can call th
 
 **Requirements:** See [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf checkout [/lock:(none|checkin|checkout)] [/recursive] [/encoding:encoding] itemspec [/login: username,[password]]
+```
+tf checkout [/lock:(none|checkin|checkout)] [/recursive] [/encoding:encoding] itemspec [/login: username,[password]]
+```
 
 ## Parameters
 
@@ -38,13 +40,17 @@ Checks out a file and changes its pending change status to Edit. You can call th
 
 ### Check out a single item
 
-    c:\code\SiteApp\Main\SolutionA\Project1\>tf checkout program.cs
+```
+c:\code\SiteApp\Main\SolutionA\Project1\>tf checkout program.cs
+```
 
 Checks out program.cs.
 
 ### Check out two items
 
-    c:\code\SiteApp\Main\SolutionA\Project1\>tf checkout program1.cs program2.c
+```
+c:\code\SiteApp\Main\SolutionA\Project1\>tf checkout program1.cs program2.c
+```
 
 Checks out the files program1.cs and program2.c.
 

--- a/docs/repos/tfvc/configure-command.md
+++ b/docs/repos/tfvc/configure-command.md
@@ -30,7 +30,9 @@ Enables an administrator to view and change the following configuration settings
 
 To use the **configure** command, you must have the **Edit server-level information** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf configure [PathOfTeamProject] [/collection:TeamProjectCollectionUrl][/login:username,[password]]
+```
+tf configure [PathOfTeamProject] [/collection:TeamProjectCollectionUrl][/login:username,[password]]
+```
 
 ## Parameters
 
@@ -67,11 +69,15 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 
 The following example displays the **Source** **Control** **Settings** dialog box in which you can examine and modify the project settings of the workspace for the c:\\projects folder.
 
-    c:\projects>tf configure
+```
+c:\projects>tf configure
+```
 
-The following example displays the myproj project settings in the project collection at http://myserver:8080/tfs/DefaultCollection.
+The following example displays the myproj project settings in the project collection at `http://myserver:8080/tfs/DefaultCollection`.
 
-    c:\projects>tf configure $/myproj / http://myserver:8080/tfs/DefaultCollection 
+```
+c:\projects>tf configure $/myproj / http://myserver:8080/tfs/DefaultCollection 
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/day-life-alm-developer-write-new-code-user-story.md
+++ b/docs/repos/tfvc/day-life-alm-developer-write-new-code-user-story.md
@@ -73,34 +73,34 @@ This is the first unit test for the class library that he is testing, so he crea
 
 The unit test project provides a C\# file into which he can write his example. At this stage, he just wants to illustrate how one of his new methods will be invoked:
 
-**C\#**
+```csharp
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-    using System;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-    namespace Fabrikam.Math.UnitTest
+namespace Fabrikam.Math.UnitTest
+{
+    [TestClass]
+    public class UnitTest1
     {
-        [TestClass]
-        public class UnitTest1
+        [TestMethod]
+        // Demonstrates how to call the method.
+        public void SignatureTest()
         {
-            [TestMethod]
-            // Demonstrates how to call the method.
-            public void SignatureTest()
-            {
-                // Create an instance:
-                var math = new Fabrikam.Math.LocalMath();
+            // Create an instance:
+            var math = new Fabrikam.Math.LocalMath();
 
-                // Get a value to calculate:
-                double input = 0.0;
+            // Get a value to calculate:
+            double input = 0.0;
 
-                // Call the method:
-                double actualResult = math.SquareRoot(input);
+            // Call the method:
+            double actualResult = math.SquareRoot(input);
 
-                // Use the result:
-                Assert.AreEqual(0.0, actualResult);
-            }
+            // Use the result:
+            Assert.AreEqual(0.0, actualResult);
         }
     }
+}
+```
 
 He writes the example in a test method because, by the time he has written his code, he wants the example to work.
 
@@ -116,44 +116,44 @@ This procedure uses the Visual Studio Unit Test Framework, but you can also use 
 
     Each unit test must be prefixed by the `TestMethod` attribute, and the unit test method should have no parameters. You can use any name that you want for a unit test method:
 
-    **C\#**
+    ```csharp
+    [TestMethod]
+    public void SignatureTest()
+    {...}
+    ```
 
-                [TestMethod]
-                public void SignatureTest()
-                {...}
-
-	**VB**
-
-				<TestMethod()>
-    			Public Sub SignatureTest()
-    			...
-    			End Sub
+    ```vb
+    <TestMethod()>
+    Public Sub SignatureTest()
+    ...
+    End Sub
+    ```
 
 -   Each test method should call a method of the `Assert` class, to indicate whether it has passed or failed. Typically, you verify that the expected and actual results of an operation are equal:
 
-	**C\#**
+    ```csharp
+    Assert.AreEqual(expectedResult, actualResult);
+    ```
 
-        Assert.AreEqual(expectedResult, actualResult);
-
-	**VB**
-
-		Assert.AreEqual(expectedResult, actualResult)
+    ```vb
+    Assert.AreEqual(expectedResult, actualResult)
+    ```
 
 -   Your test methods can call other ordinary methods that do not have the `TestMethod` attribute.  
 -   You can organize your tests into more than one class. Each class must be prefixed by the `TestClass` attribute.
 
-    **C\#**
+    ```csharp
+    [TestClass]
+    public class UnitTest1
+    { ... }
+    ```
 
-        [TestClass]
-        public class UnitTest1
-        { ... }
-
-	**VB**
-
-		<TestClass()>
-		Public Class UnitTest1
-		...
-		End Class
+    ```vb
+    <TestClass()>
+    Public Class UnitTest1
+    ...
+    End Class
+    ```
 
 For more information about how to write unit tests in C++, see [Writing Unit tests for C/C++ with the Microsoft Unit Testing Framework for C++](https://msdn.microsoft.com/library/hh598953).
 
@@ -165,12 +165,12 @@ Next, Peter creates a class library project for his new code. There is now a pro
 
 In the new project, he adds the new class and a minimal version of the method that will at least allow the test to build successfully. The quickest way to do that is to generate a class and method stub from the invocation in the test.
 
-**C\#**
-
-            public double SquareRoot(double p)
-            {
-                throw new NotImplementedException();
-            }
+```csharp
+public double SquareRoot(double p)
+{
+    throw new NotImplementedException();
+}
+```
 
 ### To generate classes and methods from tests
 
@@ -193,12 +193,12 @@ Peter builds and runs the test by pressing CTRL+R, T. The test result shows a re
 
 He makes a simple change to the code:
 
-**C\#**
-
-           public double SquareRoot(double p)
-            {
-                return 0.0;
-            }
+```csharp
+public double SquareRoot(double p)
+{
+    return 0.0;
+}
+```
 
 He runs the test again and it passes:
 
@@ -240,26 +240,26 @@ Peter replies, "The first test is just to make sure that the name and parameters
 
 Together they write the following test:
 
-**C\#**
-      
-          [TestMethod]
-            public void QuickNonZero()
-            {
-                // Create an instance to test:
-                LocalMath math = new LocalMath();
+```csharp
+[TestMethod]
+public void QuickNonZero()
+{
+    // Create an instance to test:
+    LocalMath math = new LocalMath();
 
-                // Create a test input and expected value:
-                var expectedResult = 4.0;
-                var inputValue = expectedResult * expectedResult;
+    // Create a test input and expected value:
+    var expectedResult = 4.0;
+    var inputValue = expectedResult * expectedResult;
 
-                // Run the method:
-                var actualResult = math.SquareRoot(inputValue);
+    // Run the method:
+    var actualResult = math.SquareRoot(inputValue);
 
-                // Validate the result:
-                var allowableError = expectedResult/1e6;
-                Assert.AreEqual(expectedResult, actualResult, allowableError,
-                    "{0} is not within {1} of {2}", actualResult, allowableError, expectedResult);
-            }
+    // Validate the result:
+    var allowableError = expectedResult/1e6;
+    Assert.AreEqual(expectedResult, actualResult, allowableError,
+        "{0} is not within {1} of {2}", actualResult, allowableError, expectedResult);
+}
+```
 
 > [!TIP]
 > For this function, Peter is using Test First Development, in which he first writes the unit test for a feature, and then writes code that satisfies the test. In other cases, he finds that this practice is not realistic, so instead, he writes the tests after he writes the code. But he considers it very important to write unit tests-whether before or after the code-because they keep the code stable.
@@ -280,22 +280,22 @@ Another useful practice is to set **Run Tests after Build**. This option runs th
   
 Peter writes his first attempt at the code of the method that he is developing:
 
-**C\#**
-
-        public class LocalMath
+```csharp
+public class LocalMath
+{
+    public double SquareRoot(double x)
+    {
+        double estimate = x;
+        double previousEstimate = -x;
+        while (System.Math.Abs(estimate - previousEstimate) > estimate / 1000)
         {
-            public double SquareRoot(double x)
-            {
-                double estimate = x;
-                double previousEstimate = -x;
-                while (System.Math.Abs(estimate - previousEstimate) > estimate / 1000)
-                {
-                    previousEstimate = estimate;
-                    estimate = (estimate * estimate - x) / (2 * estimate);
-                }
-                return estimate;
-            }
-            
+            previousEstimate = estimate;
+            estimate = (estimate * estimate - x) / (2 * estimate);
+        }
+        return estimate;
+    }
+```
+
 
 Peter runs the tests again and all the tests pass:
 
@@ -305,20 +305,22 @@ Peter runs the tests again and all the tests pass:
   
 Now that the code performs its main function, Peter looks at the code to find ways of making it perform better, or to make it easier to change in the future. He realizes that he can reduce the number of calculations performed in the loop:
 
-    public class LocalMath
+```csharp
+public class LocalMath
+{
+    public double SquareRoot(double x)
+    {
+        double estimate = x;
+        double previousEstimate = -x;
+        while (System.Math.Abs(estimate - previousEstimate) > estimate / 1000)
         {
-            public double SquareRoot(double x)
-            {
-                double estimate = x;
-                double previousEstimate = -x;
-                while (System.Math.Abs(estimate - previousEstimate) > estimate / 1000)
-                {
-                    previousEstimate = estimate; 
-                    estimate = (estimate + x / estimate) / 2;
-                    //was: estimate = (estimate * estimate - x) / (2 * estimate);
-                }
-                return estimate;
-            }
+            previousEstimate = estimate; 
+            estimate = (estimate + x / estimate) / 2;
+            //was: estimate = (estimate * estimate - x) / (2 * estimate);
+        }
+        return estimate;
+    }
+```
 
 He verifies that the tests still pass:
 
@@ -342,25 +344,25 @@ Peter continues his series of extension and refactoring steps, using his list of
 
 Sometimes he adds a test that requires no change to the code, but that adds to his confidence that his code works correctly. For example, he wants to make sure that the function works over a broad range of inputs. He writes more tests, such as this one:
 
-**C\#**
-
-            [TestMethod]
-            public void SqRtValueRange()
-            {
-                LocalMath math = new LocalMath();
-                for (double expectedResult = 1e-8;
-                    expectedResult < 1e+8;
-                    expectedResult = expectedResult * 3.2)
-                {
-                    VerifyOneRootValue(math, expectedResult);
-                }
-            }
-            private void VerifyOneRootValue(LocalMath math, double expectedResult)
-            {
-                double input = expectedResult * expectedResult;
-                double actualResult = math.SquareRoot(input);
-                Assert.AreEqual(expectedResult, actualResult, expectedResult / 1e6);
-            }
+```csharp
+[TestMethod]
+public void SqRtValueRange()
+{
+    LocalMath math = new LocalMath();
+    for (double expectedResult = 1e-8;
+        expectedResult < 1e+8;
+        expectedResult = expectedResult * 3.2)
+    {
+        VerifyOneRootValue(math, expectedResult);
+    }
+}
+private void VerifyOneRootValue(LocalMath math, double expectedResult)
+{
+    double input = expectedResult * expectedResult;
+    double actualResult = math.SquareRoot(input);
+    Assert.AreEqual(expectedResult, actualResult, expectedResult / 1e6);
+}
+```
 
 This test passes the first time it runs:
 
@@ -375,48 +377,50 @@ Just to make sure this result is not a mistake, he temporarily introduces a smal
   
 Peter now moves on to writing tests for exceptional inputs:
 
-    [TestMethod]
-            public void RootTestNegativeInput()
-            {
-                LocalMath math = new LocalMath();
-                try
-                {
-                    math.SquareRoot(-10.0);
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    return;
-                }
-                catch
-                {
-                    Assert.Fail("Wrong exception on negative input");
-                    return;
-                }
-                Assert.Fail("No exception on negative input");
-            }
+```csharp
+[TestMethod]
+public void RootTestNegativeInput()
+{
+    LocalMath math = new LocalMath();
+    try
+    {
+        math.SquareRoot(-10.0);
+    }
+    catch (ArgumentOutOfRangeException)
+    {
+        return;
+    }
+    catch
+    {
+        Assert.Fail("Wrong exception on negative input");
+        return;
+    }
+    Assert.Fail("No exception on negative input");
+}
+```
 
 This test puts the code into a loop. He has to use the **Cancel** button in Test Explorer. This terminates the code within 10 seconds.
 
 Peter wants to make sure that an endless loop could not happen on the build server. Although the server imposes a timeout on a complete run, it is a very long timeout, and would cause substantial delay. Therefore, he adds an explicit timeout to this test:
 
-**C\#**
-
-            [TestMethod, Timeout(1000)]
-            public void RootTestNegativeInput()
-            {...
+```csharp
+[TestMethod, Timeout(1000)]
+public void RootTestNegativeInput()
+{...
+```
 
 The explicit timeout makes the test fail.
 
 Peter then updates the code to deal with this exceptional case:
 
-**C\#**
-
-           public double SquareRoot(double x)
-            {
-                if (x <= 0.0) 
-                {
-                    throw new ArgumentOutOfRangeException();
-                }
+```csharp
+public double SquareRoot(double x)
+{
+    if (x <= 0.0) 
+    {
+        throw new ArgumentOutOfRangeException();
+    }
+```
 
 ### Regression
   
@@ -426,14 +430,14 @@ The new test passes, but there is a regression. A test that used to pass now fai
 
 Peter finds and fixes the mistake:
 
-**C\#**
-
-          public double SquareRoot(double x)
-            {
-                if (x < 0.0)  // not <=
-                {
-                    throw new ArgumentOutOfRangeException();
-                }
+```csharp
+public double SquareRoot(double x)
+{
+    if (x < 0.0)  // not <=
+    {
+        throw new ArgumentOutOfRangeException();
+    }
+```
 
 After it is fixed, all the tests pass:
 

--- a/docs/repos/tfvc/decide-between-using-local-server-workspace.md
+++ b/docs/repos/tfvc/decide-between-using-local-server-workspace.md
@@ -110,7 +110,9 @@ If you are an [administrator](https://msdn.microsoft.com/library/ms253077), you 
 
 **A:** The use of local workspaces makes [check-out locks](understand-lock-types.md) un-enforceable. If you have [sufficient permissions](../../organizations/security/permissions.md#tfvc) you can use the [workspaces command](workspaces-command.md) to see the local workspaces being used in your project collection.
 
-    tf workspaces /format:detailed /owner:* /collection:https://YourServer/YourCollection/
+```
+tf workspaces /format:detailed /owner:* /collection:https://YourServer/YourCollection/
+```
 
 ### Q: Why can't I see when some members of my team of checked out a file?
 

--- a/docs/repos/tfvc/delete-command-team-foundation-version-control.md
+++ b/docs/repos/tfvc/delete-command-team-foundation-version-control.md
@@ -27,7 +27,10 @@ Removes files and folders from the Team Foundation version control server and de
 
 To use the **delete** command, you must have the **Check out** permission set to **Allow**. If you include the **/lock** option with a value other than *none*, you must have the **Lock** permission set to **Allow**. Additionally, you must own the workspace or have the global **Administer workspaces** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf delete [/lock:(none|checkin|checkout)] [/recursive] [/login:username,[password]] itemspec
+```
+tf delete [/lock:(none|checkin|checkout)] [/recursive] [/login:username,[password]] itemspec
+```
+
 ## Parameters
 
 <table><thead>
@@ -68,7 +71,9 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example deletes 314.cs on disk in the specified local workspace folder and then, when you check in the change, removes 314.c from the version control system non-permanently.
 
-    c:\projects>tf delete 314.cs
+```
+c:\projects>tf delete 314.cs
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/destroy-command-team-foundation-version-control.md
+++ b/docs/repos/tfvc/destroy-command-team-foundation-version-control.md
@@ -30,8 +30,11 @@ After you delete the files you can synchronize the Team Foundation warehouse. Ot
 
 To use the **destroy** command, you must belong to the **Team Foundation Administrators** security group. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf destroy [/keephistory] <itemspec1>[;<versionspec>][<itemspec2>...<itemspecN>] 
-    [/stopat:<versionspec>] [/preview] [/startcleanup] [/noprompt] [/silent] [/login:username,[password]] [/collection:TeamProjectCollectionUrl]]
+```
+tf destroy [/keephistory] <itemspec1>[;<versionspec>][<itemspec2>...<itemspecN>] 
+[/stopat:<versionspec>] [/preview] [/startcleanup] [/noprompt] [/silent] [/login:username,[password]] [/collection:TeamProjectCollectionUrl]]
+```
+
 ## Parameters
 
 <table>
@@ -86,9 +89,11 @@ After the system verifies your permissions, it runs the destroy command. This co
 
 If you run **tf destroy** without specifying **/i** and **/preview**, the system displays a console **Yes** or **No** prompt for each *filespec* value. Otherwise, you can specify **Yes to all**. If you do not specify **/keephistory**, you are prompted by an interactive text that warns of pending changes, if they exist. The interactive text points to **/preview** if you want more information about the changes. If you specify **/keephistory**, you are also prompted by **Yes**, **No**, or **All** text. If you select **Yes** or **All**, the destruction process starts, and the server paths to the destroyed items appear in the Command Prompt window.
 
-    Destroyed: <serverItem1>
-    Destroyed: <serverItem2>
-    Destroyed: ...
+```
+Destroyed: <serverItem1>
+Destroyed: <serverItem2>
+Destroyed: ...
+```
 
 If you specified the *versionspec* value as a tip, the server paths displayed in the Command Prompt window include deletion IDs. For example, X123 might appear in the Command Prompt window.
 
@@ -125,7 +130,9 @@ The following example permanently deletes the file a.cs.
 
 ### Code
 
-    C:\pi\ws1>tf destroy $/proj/pi/a.cs
+```
+C:\pi\ws1>tf destroy $/proj/pi/a.cs
+```
 
 ### Description
 
@@ -133,7 +140,9 @@ The following example deletes a folder, *aFolder*, type at the command line:
 
 ### Code
 
-    C:\tf delete $/MyTeamProject/aFolder
+```
+C:\tf delete $/MyTeamProject/aFolder
+```
 
 ### Description
 
@@ -141,7 +150,9 @@ To destroy the deleted item, *aFolder*, you must type at the command line:
 
 ### Code
 
-    tf destroy $/MyTeamProject/sFolder;x123
+```
+tf destroy $/MyTeamProject/sFolder;x123
+```
 
 Where x123 is the deletion ID.
 

--- a/docs/repos/tfvc/destroy-version-controlled-files.md
+++ b/docs/repos/tfvc/destroy-version-controlled-files.md
@@ -39,20 +39,26 @@ After you delete the files, you can synchronize the Team Foundation warehouse. O
 
     -   To preview the file aFile.cs without destroying it, type at the command prompt:
 
-            >tf destroy /preview /i $/MyTeamProject/aFile.cs
+        ```
+        >tf destroy /preview /i $/MyTeamProject/aFile.cs
+        ```
 
         >**Note:**
         >  The text in the Command Prompt window displays &quot;Destroyed: $/MyTeamProject/aFile.cs&quot;, but the file is not actually destroyed when you use the **/preview** option.
 
     -   To destroy the file, aFile.cs, type at the command prompt:
 
-            >tf destroy /i $/MyTeamProject/aFile.cs
+        ```
+        >tf destroy /i $/MyTeamProject/aFile.cs
+        ```
 
         This command displays information about possible pending changes and shelvesets in the Command Prompt window. Because you specified **/i** (non-interactive), you are not prompted with a **Yes**, **No**, **Yes to all** dialog box before the files are permanently removed.
 
     -   To destroy all the files in aFolder and, at the same time, retain their history, type:
 
-            >tf destroy /keephistory $/MyTeamProject/aFolder
+        ```
+        >tf destroy /keephistory $/MyTeamProject/aFolder
+        ```
 
         >**Note:**
         >  **/preview** cannot be specified with **/keephistory**.
@@ -63,13 +69,17 @@ After you delete the files, you can synchronize the Team Foundation warehouse. O
 
         To destroy all the files in the project MyTeamProject and, at the same time, retain the history for the files up to and including 10/23/2005, type:
 
-            >tf destroy $/MyTeamProject /keephistory /stopat:D10/23/2005
+        ```
+        >tf destroy $/MyTeamProject /keephistory /stopat:D10/23/2005
+        ```
 
     -   Use the **/startcleanup** option to immediately clean up the TFVC metadata of the files that are no longer referenced by Team Foundation Server. Without this option, those metadata are removed when the database is maintained by a SQL process that runs every 5 days. Seven days after the TFVC metadata deletion, the content of the destroyed files will be deleted by another SQL process.
 
         To immediately destroy all the files in aFolder, type:
 
-            >tf destroy /startcleanup $/MyTeamProject/aFolder
+        ```
+        >tf destroy /startcleanup $/MyTeamProject/aFolder
+        ```
 
 ## See Also
 

--- a/docs/repos/tfvc/difference-command.md
+++ b/docs/repos/tfvc/difference-command.md
@@ -24,25 +24,27 @@ Compares, and if it is possible, displays differences between two files, files i
 
 To use the **difference** command, you must have the **Read** permission for all specified items set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf diff[erence] itemspec [/version:versionspec] [/type:filetype] 
-    [/format:format [/ignorespace] [/ignoreeol] [/ignorecase] [/recursive] 
-    [/options][/noprompt][/login:username,[password]]
+```
+tf diff[erence] itemspec [/version:versionspec] [/type:filetype] 
+[/format:format [/ignorespace] [/ignoreeol] [/ignorecase] [/recursive] 
+[/options][/noprompt][/login:username,[password]]
+```
 
-&nbsp;
+```
+tf diff[erence] itemspec itemspec2 [/type:filetype] [/format: format] 
+[/ignorespace] [/ignoreeol] [/ignorecase] [/recursive] [/options] [/noprompt][/login:username,[password]]
+```
 
-    tf diff[erence] itemspec itemspec2 [/type:filetype] [/format: format] 
-    [/ignorespace] [/ignoreeol] [/ignorecase] [/recursive] [/options] [/noprompt][/login:username,[password]]
+```
+tf diff[erence] [/shelveset:shelvesetname[;shelvesetowner]] 
+shelveset_itemspec [/type:filetype] 
+[/format: format] [/ignorespace] [/ignoreeol] [/ignorecase] 
+[/recursive] [/options] [/noprompt][/login:username,[password]]
+```
 
-&nbsp;
-
-    tf diff[erence] [/shelveset:shelvesetname[;shelvesetowner]] 
-    shelveset_itemspec [/type:filetype] 
-    [/format: format] [/ignorespace] [/ignoreeol] [/ignorecase] 
-    [/recursive] [/options] [/noprompt][/login:username,[password]]
-
-&nbsp;
-
-    tf diff[erence] /configure
+```
+tf diff[erence] /configure
+```
 
 ## Parameters
 
@@ -166,22 +168,25 @@ The *format* parameter, used with the **/format** option, specifies many differe
 
   The **Unix** output format is constructed in the following way:
 
-          <metadataline>
-      "< " line prefix for lines from the first file
-      "---" line
-      "> " line prefix for lines from the second file
+    ```
+    <metadataline>
+    "< " line prefix for lines from the first file
+    "---" line
+    "> " line prefix for lines from the second file
 
-      <metadataline> can be one of these possibilities:
-      #a#,# -- add lines from line # in file1 into file2 at lines #->#
-      #,#d# -- delete lines from line # -> # in file 1 from file2 at line #
-      #,#c#,# -- change lines from line # -> # in file1 into the lines in file2 at line # -> #
+    <metadataline> can be one of these possibilities:
+    #a#,# -- add lines from line # in file1 into file2 at lines #->#
+    #,#d# -- delete lines from line # -> # in file 1 from file2 at line #
+    #,#c#,# -- change lines from line # -> # in file1 into the lines in file2 at line # -> #
 
-      # signs separated by commas indicate a line range.
-      # signs before the character indicate line numbers in the first file
-      # signs after the character indicate line numbers in the second file
+    # signs separated by commas indicate a line range.
+    # signs before the character indicate line numbers in the first file
+    # signs after the character indicate line numbers in the second file
 
-      /// No end of line marker at the end of the file:
-      /// \ No newline at end of file
+    /// No end of line marker at the end of the file:
+    /// \ No newline at end of file
+    ```
+
   ## Examples
   The following example displays the differences between the local version of 314.cs and the workspace version of 314.cs that is the version of the file that was checked out from the Team Foundation version control server.
 
@@ -189,27 +194,39 @@ The *format* parameter, used with the **/format** option, specifies many differe
 
 The following example displays all files that have been changed in the src folder. Does not display files that have been changed in subfolders of src.
 
-    c:\projects>tf difference src /format:visual
+```
+c:\projects>tf difference src /format:visual
+```
 
 The following example displays the differences between changeset 3 and changeset 8 of 1254.cs.
 
-    c:\projects>tf difference /version:C3~C8 1254.cs
+```
+c:\projects>tf difference /version:C3~C8 1254.cs
+```
 
 The following examples display the differences between the version of 314.cs that belong to the label "release" and the version that belongs to changeset 3200.
 
-    c:\projects>tf difference 314.cs;Lrelease 314.cs;C3200
+```
+c:\projects>tf difference 314.cs;Lrelease 314.cs;C3200
+```
 
 -or-
 
-    c:\projects>tf difference 314.cs;Lrelease~C3200
+```
+c:\projects>tf difference 314.cs;Lrelease~C3200
+```
 
 The following example displays the difference between the versions of e271.cs that a user named Nadia shelved in shelveset PeerCodeReview8 and the *base shelveset version* that is the version upon which she based her changes. Also displays the types of changes pending against e271.cs when Nadia shelved.
 
-    c:\projects> tf difference /shelveset:PeerCodeReview8;Nadia e271.cs
+```
+c:\projects> tf difference /shelveset:PeerCodeReview8;Nadia e271.cs
+```
 
 The following example displays the differences between all files in the PeerCodeReview2 shelveset and the base shelveset version of those files.
 
-    c:\projects> tf difference /shelveset:PeerCodeReview2
+```
+c:\projects> tf difference /shelveset:PeerCodeReview2
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/dir-command.md
+++ b/docs/repos/tfvc/dir-command.md
@@ -22,10 +22,13 @@ The **dir** command displays all or some of the contents of the server for Team 
 
 **Required Permissions**
 
-To use the **dir** command, you must have **Read** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
+To use the **dir** command, you must have **Read** permission set to **Allow**. For more 
+information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf dir itemspec [/version:versionspec] [/recursive] 
-    [/folders] [/deleted] [/login:username,[password]] [/collection:TeamProjectCollectionUrl]
+```
+tf dir itemspec [/version:versionspec] [/recursive] 
+[/folders] [/deleted] [/login:username,[password]] [/collection:TeamProjectCollectionUrl]
+```
 
 ## Parameters<table>
 <thead>
@@ -107,27 +110,39 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example displays a list of files, folders, subfolders, and the files therein in the Team Foundation version control server folder to which c:\\projects maps. The number of items is also listed. For more information about how to view and edit working folder mappings, see [Workspace Command](workspace-command.md) and [Workfold Command](workfold-command.md).
 
-    c:\projects>tf dir /recursive
+```
+c:\projects>tf dir /recursive
+```
 
 The following example displays all Team Foundation version control server files at that path. The "314dir" subfolder does not have to exist in the local folder.
 
-    c:\projects>tf dir 314dir
+```
+c:\projects>tf dir 314dir
+```
 
 The following example displays the version of files labeled "My label" in that Team Foundation version control server path. The "314dir" subfolder does not have to exist in the local folder.
 
-    c:\projects>tf dir /version:L"My label" 314dir
+```
+c:\projects>tf dir /version:L"My label" 314dir
+```
 
 The following example displays all folders in the root of the Team Foundation version control server. The local working folder is ignored because `$/` denotes a Team Foundation version control server path.
 
-    c:\projects>tf dir /folders $/
+```
+c:\projects>tf dir /folders $/
+```
 
 The following example lists every file and folder in the Team Foundation version control server.
 
-    c:\projects>tf dir /recursive $/
+```
+c:\projects>tf dir /recursive $/
+```
 
 The following example lists all items and deleted items in the current folder together with their deletion IDs.
 
-    c:\projects>tf dir /deleted
+```
+c:\projects>tf dir /deleted
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/find-view-changesets.md
+++ b/docs/repos/tfvc/find-view-changesets.md
@@ -120,7 +120,9 @@ The **Changeset Details** view in Team Explorer has links to perform the followi
 
 To find a changeset from the [command prompt](use-team-foundation-version-control-commands.md):
 
-    c:\users\jamal\workspaces\fabrikam>tf changeset
+```
+c:\users\jamal\workspaces\fabrikam>tf changeset
+```
 
 To view or modify changesets and to learn about other options, see [Changeset Command](changeset-command.md).
 

--- a/docs/repos/tfvc/folderdiff-command.md
+++ b/docs/repos/tfvc/folderdiff-command.md
@@ -24,7 +24,9 @@ Use the **folderdiff** command to display and compare a visual representation of
 
 To use the **folderdiff** command, you must have the **Read** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf folderdiff [sourcePath] targetPath [/recursive] [/noprompt] [/collection:TeamProjectCollectionUrl] [/filter:filter] [/filterLocalPathsOnly] [/login:username,[password]] [/view:same,different,sourceOnly,targetOnly]
+```
+tf folderdiff [sourcePath] targetPath [/recursive] [/noprompt] [/collection:TeamProjectCollectionUrl] [/filter:filter] [/filterLocalPathsOnly] [/login:username,[password]] [/view:same,different,sourceOnly,targetOnly]
+```
 
 ## Parameters<table>
 <thead>
@@ -156,7 +158,9 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example compares the files in the server folder and a local folder. It organizes the files in the localFolder recursively and displays the output in the Command Prompt window.
 
-    C:>tf folderdiff $/serverFolder F:\localFolder /recursive /noprompt
+```
+C:>tf folderdiff $/serverFolder F:\localFolder /recursive /noprompt
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/get-command.md
+++ b/docs/repos/tfvc/get-command.md
@@ -22,9 +22,11 @@ Gets (downloads) either the latest version or a specified version of one or more
 
 **Requirements:** See [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf get [itemspec] [/version:versionspec] [/all] [/overwrite] [/force] [/remap]
-    [/recursive] [/preview] [/noautoresolve] [/noprompt]
-    [/login:username,[password]]
+```
+tf get [itemspec] [/version:versionspec] [/all] [/overwrite] [/force] [/remap]
+[/recursive] [/preview] [/noautoresolve] [/noprompt]
+[/login:username,[password]]
+```
 
 ## Parameters
 
@@ -94,37 +96,49 @@ In all the following examples, assume that `$/SiteApp/Main/` is mapped to `c:\\c
 
 ### Get the latest version of all items in a workspace
 
-    c:\code\SiteApp\Main\SolutionA>tf get
+```
+c:\code\SiteApp\Main\SolutionA>tf get
+```
 
 Gets the latest versions of all items in the workspace. For example, the above command would recursively get all files in `$/SiteApp/Main/` including all its child folders.
 
 ### Recursively get the latest version of items of a certain type in a folder
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf get *.cs /recursive
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf get *.cs /recursive
+```
 
 Gets the latest version of all C\# (.cs) files in `c:\\code\\SiteApp\\Main\\SolutionA\\Project1`.
 
 ###  Get the latest version of a file
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf get program.cs
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf get program.cs
+```
 
 Gets the latest version of program.cs in Project1.
 
 ### Get a specific version of a file
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf get program.cs;8
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf get program.cs;8
+```
 
 Gets version 8 of program.cs in Project1.
 
 ### Get the latest version of two files
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf get file1.cs file2.cs
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf get file1.cs file2.cs
+```
 
 Gets the latest version of file1.cs and file2.cs in Project1.
 
 ### Synchronize a workspace to match a version of the team's codebase
 
-    c:\code\SiteApp\Main>tf get /v:15
+```
+c:\code\SiteApp\Main>tf get /v:15
+```
 
 Synchronizes the workspace to match the codebase as it existed when changeset 15 was created:
 
@@ -136,7 +150,9 @@ Synchronizes the workspace to match the codebase as it existed when changeset 15
 
 ### Synchronize a workspace to match a labeled version of the team's codebase
 
-    c:\code\SiteApp\Main>tf get /v:LLastKnownGood
+```
+c:\code\SiteApp\Main>tf get /v:LLastKnownGood
+```
 
 Synchronizes the workspace to match the items in the codebase that are [labeled](use-labels-take-snapshot-your-files.md) **LastKnownGood**:
 

--- a/docs/repos/tfvc/git-view-command.md
+++ b/docs/repos/tfvc/git-view-command.md
@@ -22,13 +22,15 @@ Retrieves a file from a Git repository to a temporary location on your computer 
 
 **Requirements:** See [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf git view /collection:TeamProjectCollectionUrl
-                /teamproject:TeamProjectIdentifier
-                /repository:RepositoryIdentifier
-                (/blobId:blobId | /path:path [/commitId:commitId])
-                [/output:localfile]
-                [/console]
-                [/login:username,[password]]
+```
+tf git view /collection:TeamProjectCollectionUrl
+            /teamproject:TeamProjectIdentifier
+            /repository:RepositoryIdentifier
+            (/blobId:blobId | /path:path [/commitId:commitId])
+            [/output:localfile]
+            [/console]
+            [/login:username,[password]]
+```
 
 ## Parameters
 

--- a/docs/repos/tfvc/help-command-team-foundation-version-control.md
+++ b/docs/repos/tfvc/help-command-team-foundation-version-control.md
@@ -20,7 +20,10 @@ monikerRange: '>= tfs-2015'
 
 Displays help on the command line that contains information about syntax for a Team Foundation version control command.
 
-    tf help commandname
+```
+tf help commandname
+```
+
 ## Parameters<table>
 <thead>
 <tr>
@@ -46,15 +49,21 @@ For more information about how to find the **tf** command-line utility, see [Tf 
 ## Examples
 The following example displays a list of the version control commands.
 
-    c:\projects>tf help
+```
+c:\projects>tf help
+```
 
 The following example displays information about syntax for the **workspace** command.
 
-    c:\projects>tf help workspace
+```
+c:\projects>tf help workspace
+```
 
 The following example also displays the same information about syntax for the **workspace** command.
 
-    c:\projects>tf workspace /?
+```
+c:\projects>tf workspace /?
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/history-command.md
+++ b/docs/repos/tfvc/history-command.md
@@ -22,11 +22,13 @@ Displays the revision history of one or more files or folders. The data is displ
 
 **Requirements:** See [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf hist[ory] itemspec [/version:versionspec] 
-    [/stopafter:number] [/recursive] [/user:username] 
-    [/format:(brief|detailed)] [/slotmode] [/itemmode] [/noprompt]
-    [/login:username,[password]] [/sort:ascending,descending]
-    [/collection:TeamProjectCollectionUrl]
+```
+tf hist[ory] itemspec [/version:versionspec] 
+[/stopafter:number] [/recursive] [/user:username] 
+[/format:(brief|detailed)] [/slotmode] [/itemmode] [/noprompt]
+[/login:username,[password]] [/sort:ascending,descending]
+[/collection:TeamProjectCollectionUrl]
+```
 
 ## Parameters
 
@@ -114,138 +116,172 @@ Displays the revision history of one or more files or folders. The data is displ
 
 ### Get history of a single file
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf history program2.cs
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf history program2.cs
+```
 
 Displays all changes made to program.cs in the History window.
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf history program2.cs /noprompt
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf history program2.cs /noprompt
+```
 
 Displays all changes made to program.cs in the command prompt window. For example:
 
-    Changeset Change                     User              Date       Comment
-    --------- -------------------------- ----------------- ---------- -------- 
-    29        edit                       Jamal Hartnett    4/23/2012  Fix bug
-    20        add                        Raisa Pokrovskaya 4/12/2012  Add new  
+```
+Changeset Change                     User              Date       Comment
+--------- -------------------------- ----------------- ---------- -------- 
+29        edit                       Jamal Hartnett    4/23/2012  Fix bug
+20        add                        Raisa Pokrovskaya 4/12/2012  Add new  
+```
 
 ### Get history of all items in a folder
 
-    c:\code\SiteApp\Main\SolutionA>tf history * /recursive
+```
+c:\code\SiteApp\Main\SolutionA>tf history * /recursive
+```
 
 Displays all changes made to all items in SolutionA (including those in subfolders) in the History window.
 
 ### Get history of the last five changes to all items in a folder
 
-    c:\code\SiteApp\Main\SolutionA>tf history * /noprompt /recursive /stopafter:5
+```
+c:\code\SiteApp\Main\SolutionA>tf history * /noprompt /recursive /stopafter:5
+```
 
 Displays the latest 5 changes made to items in SolutionA (including those in subfolders):
 
-    Changeset User              Date       Comment
-    --------- ----------------- ---------- ----------------------------------------
-    31        Raisa Pokrovskaya 5/15/2012
-    30        Raisa Pokrovskaya 4/23/2012
-    29        Jamal Hartnett    4/23/2012  Fix bug in new method
-    20        Raisa Pokrovskaya 4/12/2012  Add new method, add program2.cs to Proje
-    15        Raisa Pokrovskaya 4/8/2012
+```
+Changeset User              Date       Comment
+--------- ----------------- ---------- ----------------------------------------
+31        Raisa Pokrovskaya 5/15/2012
+30        Raisa Pokrovskaya 4/23/2012
+29        Jamal Hartnett    4/23/2012  Fix bug in new method
+20        Raisa Pokrovskaya 4/12/2012  Add new method, add program2.cs to Proje
+15        Raisa Pokrovskaya 4/8/2012
+```
 
 ### Get history from version x and earlier
 
-    c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:30
+```
+c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:30
+```
 
 Displays changes made to all items in SolutionA (including those in subfolders) in version 30 and earlier:
 
-    Changeset User              Date       Comment
-    --------- ----------------- ---------- ----------------------------------------
-    30        Raisa Pokrovskaya 4/23/2012
-    29        Jamal Hartnett    4/23/2012  Fix bug in new method
-    20        Raisa Pokrovskaya 4/12/2012  Add new method, add program2.cs to 15        Raisa Pokrovskaya 4/8/2012
+```
+Changeset User              Date       Comment
+--------- ----------------- ---------- ----------------------------------------
+30        Raisa Pokrovskaya 4/23/2012
+29        Jamal Hartnett    4/23/2012  Fix bug in new method
+20        Raisa Pokrovskaya 4/12/2012  Add new method, add program2.cs to 15        Raisa Pokrovskaya 4/8/2012
+```
 
 ### Get history from date D and earlier
 
-    c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D4/24/2012
+```
+c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D4/24/2012
+```
 
 -- or --
 
-    c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D2012-04-24T12:00
+```
+c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D2012-04-24T12:00
+```
 
 Displays changes made to all items in SolutionA (including those in subfolders) on 4/23/12 or earlier:
 
-    Changeset User              Date       Comment
-    --------- ----------------- ---------- ----------------------------------------
-    30        Raisa Pokrovskaya 4/23/2012
-    29        Jamal Hartnett    4/23/2012  Fix bug in new method
-    20        Raisa Pokrovskaya 4/12/2012  Add new method, add program2.cs to 15        Raisa Pokrovskaya 4/8/2012
+```
+Changeset User              Date       Comment
+--------- ----------------- ---------- ----------------------------------------
+30        Raisa Pokrovskaya 4/23/2012
+29        Jamal Hartnett    4/23/2012  Fix bug in new method
+20        Raisa Pokrovskaya 4/12/2012  Add new method, add program2.cs to 15        Raisa Pokrovskaya 4/8/2012
+```
 
 ### Get history from version x to version y
 
-    c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D4/12/2012~D4/24/2012
+```
+c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D4/12/2012~D4/24/2012
+```
 
 Displays changes made to all items in SolutionA (including those in subfolders) between 4/12/2012 and 4/23/12:
 
-    Changeset User              Date       Comment
-    --------- ----------------- ---------- ----------------------------------------
-    30        Raisa Pokrovskaya 4/23/2012
-    29        Jamal Hartnett    4/23/2012  Fix bug in new method
-    20        Raisa Pokrovskaya 4/12/2012  Add new method, add program2.cs to 
+```
+Changeset User              Date       Comment
+--------- ----------------- ---------- ----------------------------------------
+30        Raisa Pokrovskaya 4/23/2012
+29        Jamal Hartnett    4/23/2012  Fix bug in new method
+20        Raisa Pokrovskaya 4/12/2012  Add new method, add program2.cs to 
+```
 
 ### Get detailed history
 
-    c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D4/12/2012~D4/24/2012 /format:detailed
+```
+c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D4/12/2012~D4/24/2012 /format:detailed
+```
 
 Displays details about changes made to all items in SolutionA (including those in subfolders) between 4/12/2012 and 4/23/12:
 
-   -------------------------------------------------------------------------------
-    Changeset: 30
-    User: Raisa Pokrovskaya (Fabrikam)
-    Date: Monday, April 23, 2012 1:23:05 PM
+```
+-------------------------------------------------------------------------------
+Changeset: 30
+User: Raisa Pokrovskaya (Fabrikam)
+Date: Monday, April 23, 2012 1:23:05 PM
 
-    Comment:
-      Much better name for this file
+Comment:
+  Much better name for this file
 
-    Items:
-      rename                $/SiteApp/Main/SolutionA/Project1/programBig.cs
-      delete, source rename $/SiteApp/Main/SolutionA/Project1/program3.cs;X15
+Items:
+  rename                $/SiteApp/Main/SolutionA/Project1/programBig.cs
+  delete, source rename $/SiteApp/Main/SolutionA/Project1/program3.cs;X15
 
-    -------------------------------------------------------------------------------
-    Changeset: 29
-    User: Raisa Pokrovskaya (Fabrikam)
-    Date: Monday, April 23, 2012 1:03:13 PM
+-------------------------------------------------------------------------------
+Changeset: 29
+User: Raisa Pokrovskaya (Fabrikam)
+Date: Monday, April 23, 2012 1:03:13 PM
 
-    Comment:
-      Fix bug in new method
+Comment:
+  Fix bug in new method
 
-    Items:
-      edit $/SiteApp/Main/SolutionA/Project1/program1.cs
-      edit $/SiteApp/Main/SolutionA/Project1/program2.cs
+Items:
+  edit $/SiteApp/Main/SolutionA/Project1/program1.cs
+  edit $/SiteApp/Main/SolutionA/Project1/program2.cs
 
-    -------------------------------------------------------------------------------
-    Changeset: 20
-    User: Raisa Pokrovskaya (Fabrikam)
-    Date: Thursday, April 12, 2012 5:09:35 PM
+-------------------------------------------------------------------------------
+Changeset: 20
+User: Raisa Pokrovskaya (Fabrikam)
+Date: Thursday, April 12, 2012 5:09:35 PM
 
-    Comment:
-      Add new method, add program2.cs to Project1
+Comment:
+  Add new method, add program2.cs to Project1
 
-    Items:
-      add $/SiteApp/Main/SolutionA/Project1/program2.cs
+Items:
+  add $/SiteApp/Main/SolutionA/Project1/program2.cs
 
-    Check-in Notes:
-      Documentation:
-        An important new part of our codebase.
+Check-in Notes:
+  Documentation:
+    An important new part of our codebase.
 
-    Policy Warnings:
-      Override Reason:
-        Jamal agrees with me that we can bypass for this check-in.
-      Messages:
-        The Code Analysis Policy requires files to be checked in through Visual
-    Studio with an open solution.
+Policy Warnings:
+  Override Reason:
+    Jamal agrees with me that we can bypass for this check-in.
+  Messages:
+    The Code Analysis Policy requires files to be checked in through Visual
+Studio with an open solution.
+```
 
 ### Get the non-recursive history of a folder
 
-    c:\code\SiteApp\Main\SolutionA>tf history .
+```
+c:\code\SiteApp\Main\SolutionA>tf history .
+```
 
 Displays the history of the SolutionA folder in the History window, which enables you to explore earlier changes to the folder. For example, if the most recent change to the folder was a rename, you can expand the changeset to see changes that occurred before the rename.
 
-    c:\code\SiteApp\Main\SolutionA>tf history . /noprompt
+```
+c:\code\SiteApp\Main\SolutionA>tf history . /noprompt
+```
 
 Displays the most recent change to the SolutionA folder in the command prompt window.
 

--- a/docs/repos/tfvc/label-command-team-foundation-version-control.md
+++ b/docs/repos/tfvc/label-command-team-foundation-version-control.md
@@ -26,12 +26,16 @@ Attaches a label to or removes a label from a version of a file or folder in the
 
 To use the **label** command, you must have the **Label** permission set to **Allow**. To modify or delete labels created by other users, you must have the **Administer labels** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf label labelname[@scope] [/owner:ownername] 
-    itemspec [/version:versionspec] [/comment:("comment"|@commentfile)] 
-    [/child:(replace|merge)] [/recursive] [/login:username,[password]] [/collection:TeamProjectCollectionUrl]	
+```
+tf label labelname[@scope] [/owner:ownername] 
+itemspec [/version:versionspec] [/comment:("comment"|@commentfile)] 
+[/child:(replace|merge)] [/recursive] [/login:username,[password]] [/collection:TeamProjectCollectionUrl]	
+```
 
-	tf label /delete labelname[@scope] 
-    itemspec [/login:username,[password]] [/collection:TeamProjectCollectionUrl]
+```
+tf label /delete labelname[@scope] 
+itemspec [/login:username,[password]] [/collection:TeamProjectCollectionUrl]
+```
 
 ## Parameters
 
@@ -147,23 +151,33 @@ You can prevent other users from "overloading" a label such as "M3" in different
 ## Examples
 The following example attaches the "goodbuild" label to the workspace version of the "docs" folder and the files and folders it contains.
 
-    c:\projects>tf label goodbuild docs /recursive
+```
+c:\projects>tf label goodbuild docs /recursive
+```
 
 The following example attaches the "goodbuild" label to the "docs" folder but not the files and folders the docs folder contains.
 
-    c:\projects>tf label goodbuild docs
+```
+c:\projects>tf label goodbuild docs
+```
 
 The following example attaches the "goodbuild" label to version 3 of 314.cs in the Team Foundation version control server.
 
-    c:\projects>tf label goodbuild /version:3 $/src/314.cs
+```
+c:\projects>tf label goodbuild /version:3 $/src/314.cs
+```
 
 The following example deletes the "badbuild" label from all items in the Team Foundation version control server.
 
-    c:\projects>tf label /delete badbuild
+```
+c:\projects>tf label /delete badbuild
+```
 
 The following example uses the scope option to apply a label to 314.cs.
 
-    c:\projects>tf label goodbuild@$/TeamProject1 314.cs
+```
+c:\projects>tf label goodbuild@$/TeamProject1 314.cs
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/labels-command.md
+++ b/docs/repos/tfvc/labels-command.md
@@ -24,8 +24,10 @@ Displays the list of labels in the server for Team Foundation version control.
 
 To use the **labels** command, you must have the **Read** permission set to **Allow** for all files or folders to which the specified label is attached. If you have permission to some, but not all the files referenced in the label, partial results are displayed. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf labels [/owner:ownername] [/format:(brief|detailed)] 
-    [/collection:TeamProjectCollectionUrl] [labelname] [/login:username,[password]]
+```
+tf labels [/owner:ownername] [/format:(brief|detailed)] 
+[/collection:TeamProjectCollectionUrl] [labelname] [/login:username,[password]]
+```
 
 ## Parameters<table>
 
@@ -54,15 +56,21 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example displays the list of labels created by user "jasonj."
 
-    c:\projects> tf labels /owner:jasonj
+```
+c:\projects> tf labels /owner:jasonj
+```
 
 The following example displays information about "build1033" label and lists the files and folders to which the label has been applied in the Team Foundation version control server.
 
-    c:\projects> tf labels /format:detailed build1033
+```
+c:\projects> tf labels /format:detailed build1033
+```
 
 The following example displays all labels in the Team Foundation version control server that have a *labelname* that begins with "build" and are owned by the account executing the **labels** command.
 
-    c:\projects> tf labels build*
+```
+c:\projects> tf labels build*
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/localversions-command.md
+++ b/docs/repos/tfvc/localversions-command.md
@@ -23,9 +23,11 @@ Displays the version of one or more items in a workspace.
 **Required Permissions**  
 To use the **localversions** command, you must have the **Use** permission to the workspace. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf localversions ItemSpec
-    [/recursive] [/format:brief|detailed]
-    [/workspace:WorkspaceName[;WorkspaceOwner]] [/collection:TeamProjectCollectionUrl]
+```
+tf localversions ItemSpec
+[/recursive] [/format:brief|detailed]
+[/workspace:WorkspaceName[;WorkspaceOwner]] [/collection:TeamProjectCollectionUrl]
+```
 
 ## Parameters
 <table>
@@ -112,11 +114,15 @@ For more information about how to find and use the **tf** command-line utility, 
 ## Examples
 The following example displays the version of the `ControllerBase.cs` file in the workspace that is mapped to the `c:\\workspaces\\FeatureA\\catalog\\controller` folder.
 
-    c:\workspaces\FeatureA\catalog\controller>tf localversions ControllerBase.cs
+```
+c:\workspaces\FeatureA\catalog\controller>tf localversions ControllerBase.cs
+```
 
 The following example displays the versions of all files (including those in subfolders) in the workspace that is mapped to the `c:\\workspaces\\FeatureA\\catalog\\` folder. Because the **/format:detailed** option is specified, each file appears with its full path.
 
-    c:\workspaces\FeatureA\catalog\>tf localversions . /recursive /format:detailed
+```
+c:\workspaces\FeatureA\catalog\>tf localversions . /recursive /format:detailed
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/lock-command.md
+++ b/docs/repos/tfvc/lock-command.md
@@ -24,8 +24,10 @@ Locks or unlocks a file or folder to deny or restore the right of users to check
 
 To use the **lock** command, you must have the **Lock** permission set to **Allow**. Having the Unlock other user's changes permission set to **Allow** is required to remove a lock held by another user if you do not have **Write** permission for that user's workspace. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md#lock-permission).
 
-    tf lock itemspec /lock:(none|checkout|checkin) 
-    [/workspace:workspacename] [/recursive] [/login:username,[password]] [/collection:TeamProjectCollectionUrl] 
+```
+tf lock itemspec /lock:(none|checkout|checkin) 
+[/workspace:workspacename] [/recursive] [/login:username,[password]] [/collection:TeamProjectCollectionUrl] 
+```
 
 ## Parameters
 
@@ -113,19 +115,27 @@ You can determine which files are locked in the Team Foundation version control 
 ## Examples
 The following example prevents other users from checking out 314.cs.
 
-    c:\projects>tf lock /lock:checkout 314.cs
+```
+c:\projects>tf lock /lock:checkout 314.cs
+```
 
 The following example prevents other users from checking in changes to 1256.cs but enables them to check it out in their workspaces.
 
-    c:\projects>tf lock /lock:checkin 1256.cs
+```
+c:\projects>tf lock /lock:checkin 1256.cs
+```
 
 The following example prevents other users from pending changes to any items in the src/ folder in the Team Foundation version control server.
 
-    c:\projects>tf lock /lock:checkout $/src
+```
+c:\projects>tf lock /lock:checkout $/src
+```
 
 The following example unlocks and makes all files in the src/ Team Foundation version control server folder available for check-out and check-in by other users.
 
-    c:\projects>tf lock /lock:none src/
+```
+c:\projects>tf lock /lock:none src/
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/merge-command.md
+++ b/docs/repos/tfvc/merge-command.md
@@ -27,9 +27,12 @@ The **merge** command applies changes from one branch into another.
 
 To use the **merge** command, you must have the **Check out** permission set to **Allow** for the workspace folder that contains the *destination* and you must have the **Read** permission set to **Allow** for the workspace folder that contains the source. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf merge [/recursive] [/force] [/candidate] [/discard] 
-    [/version:versionspec] [/lock:none|checkin|checkout] [/preview] 
-    [/baseless] [/nosummary] [/noimplicitbaseless] [/conservative] [/format:(brief|detailed)] [/noprompt] [/login:username,[password]] source destination
+```
+tf merge [/recursive] [/force] [/candidate] [/discard] 
+[/version:versionspec] [/lock:none|checkin|checkout] [/preview] 
+[/baseless] [/nosummary] [/noimplicitbaseless] [/conservative] [/format:(brief|detailed)] [/noprompt] [/login:username,[password]] source destination
+```
+
 ## Parameters
 
 |**Argument**|**Description**|
@@ -104,27 +107,39 @@ If you run **tf merge** with the **/noimplicitbaseless** option set, when Team F
 ## Examples
 The following example merges changes from MyFile\_beta1 that have not been merged into MyFile\_RTM.
 
-    c:\projects>tf merge MyFile_beta1 MyFile_RTM /recursive
+```
+c:\projects>tf merge MyFile_beta1 MyFile_RTM /recursive
+```
 
 The following example merges changeset 137 into branch2.
 
-    c:\projects>tf merge /version:C137~C137 branch1 branch2 /recursive
+```
+c:\projects>tf merge /version:C137~C137 branch1 branch2 /recursive
+```
 
 The following example merges all the changesets up to changeset 137 into branch2.
 
-    c:\projects>tf merge /version:C137 branch1 branch2 /recursive
+```
+c:\projects>tf merge /version:C137 branch1 branch2 /recursive
+```
 
 The following example prints a list of the changesets in branch1 that have not been merged into branch2.
 
-    c:\projects>tf merge /candidate branch1 branch2 /recursive
+```
+c:\projects>tf merge /candidate branch1 branch2 /recursive
+```
 
 The following example prints a list of changesets in branch2 that have not been merged back into branch1.
 
-    c:\projects>tf merge /candidate branch2 branch1 /recursive
+```
+c:\projects>tf merge /candidate branch2 branch1 /recursive
+```
 
 The following example discards changeset 137 as a candidate for merging into branch2.
 
-    c:\projects>tf merge /discard /version:C137 branch1 branch2 /recursive
+```
+c:\projects>tf merge /discard /version:C137 branch1 branch2 /recursive
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/merges-command.md
+++ b/docs/repos/tfvc/merges-command.md
@@ -23,7 +23,9 @@ Displays detailed information about past merges between the specified source and
 **Required Permissions**  
 To use the **merges** command, you must have the **Read** permission set to **Allow** for both source and destination branches. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf merges [source] destination [/recursive] [/extended] [/format:(brief|detailed)] [/login:username, [password]] [/showall]]] [/collection:TeamProjectCollectionUrl]
+```
+tf merges [source] destination [/recursive] [/extended] [/format:(brief|detailed)] [/login:username, [password]] [/showall]]] [/collection:TeamProjectCollectionUrl]
+```
 
 ## Parameters<table>
 
@@ -77,15 +79,19 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 
 The following example displays information about all merge operations performed between Beta1\_branch and RTM\_branch.
 
-    c:\projects>tf merges /recursive Beta1_branch RTM_branch
+```
+c:\projects>tf merges /recursive Beta1_branch RTM_branch
+```
 
 -   Sample output:
 
-        Changeset  Merged in Changeset   Author   Date
-        --------------------------------------------------------
-        135         162                   Justin     10/31/2003
-        146         162                   Justin      10/31/2003
-        147*        167                   Bill       11/02/2003
+    ```
+	Changeset  Merged in Changeset   Author   Date
+	--------------------------------------------------------
+	135         162                   Justin     10/31/2003
+	146         162                   Justin      10/31/2003
+	147*        167                   Bill       11/02/2003
+    ```
 
     The asterisk '\*' next to changeset 147 indicates that only some of the changes in that changeset \#147 were merged into changeset \#167.
 

--- a/docs/repos/tfvc/msdn-command.md
+++ b/docs/repos/tfvc/msdn-command.md
@@ -20,7 +20,10 @@ monikerRange: '>= tfs-2015'
 
 Displays a help topic from the MSDN library that contains detailed information about a Team Foundation version control command.
 
-    tf msdn commandname
+```
+tf msdn commandname
+```
+
 ## Parameters
 | **Argument** | **Description** |
 |---|---|
@@ -36,11 +39,15 @@ For more information about how to find the **tf** command-line utility, see [Tf 
 ## Examples
 The following example displays a help topic that lists all the version control commands, including a brief explanation of syntax.
 
-    c:\projects>tf msdn
+```
+c:\projects>tf msdn
+```
 
 The following example displays a help topic about the **workspace** command.
 
-    c:\projects>tf msdn workspace
+```
+c:\projects>tf msdn workspace
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/permission-command.md
+++ b/docs/repos/tfvc/permission-command.md
@@ -24,11 +24,14 @@ Modifies the user access control list (ACL) and displays authorization settings 
 
 To use the **permission** command, you must have the **Manipulate security settings** permission set to **Allow** for the folders being modified, be a member of the **Team Foundation Administrators** security group, or be a system administrator on the local computer (Windows Administrator security group). For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf permission [/allow:(* |perm1[,perm2,...]] 
-    [/deny:(* |perm1[,perm2,...])] [/remove:(* |perm1[,perm2,...])] 
-    [/inherit:yes|no] [/user:username1[,username2,...]] 
-    [/group:groupname1[,groupname2,...]] [/collection:TeamProjectCollectionUrl] 
-    [/recursive] itemspec [/global][/login:username,[password]]
+```
+tf permission [/allow:(* |perm1[,perm2,...]] 
+[/deny:(* |perm1[,perm2,...])] [/remove:(* |perm1[,perm2,...])] 
+[/inherit:yes|no] [/user:username1[,username2,...]] 
+[/group:groupname1[,groupname2,...]] [/collection:TeamProjectCollectionUrl] 
+[/recursive] itemspec [/global][/login:username,[password]]
+```
+
 ## Parameters
 
 <table>
@@ -145,31 +148,45 @@ For more information about how to find the **tf** command-line utility, see [Tf 
 ## Examples
 The following example displays the Team Foundation access control lists (ACLs) for 314.cs.
 
-    c:\projects>tf permission 314.cs
+```
+c:\projects>tf permission 314.cs
+```
 
 The following example displays the ACL information that relates to the group "developers" for the collection that is located at http://myserver:8080/tfs/DefaultCollection/.
 
-    c:\projects>tf permission /group:[teamproject]\developers /collection: http://myserver:8080/tfs/DefaultCollection/
+```
+c:\projects>tf permission /group:[teamproject]\developers /collection: http://myserver:8080/tfs/DefaultCollection/
+```
 
 The following example enables members of the "leads" group to change their local copies of all items in the $/baseobjects Team Foundation version control server folder.
 
-    c:\projects>tf permission /allow:PendChange /group:[teamproject]\leads $/baseobjects
+```
+c:\projects>tf permission /allow:PendChange /group:[teamproject]\leads $/baseobjects
+```
 
 The following example removes all permission-related settings from the $/baseobjects folder for members of the "developers" group.
 
-    c:\projects>tf permission /remove:* /group:developers $/baseobjects
+```
+c:\projects>tf permission /remove:* /group:developers $/baseobjects
+```
 
 The following example enables the group "testers" to change their local copies of all items in $/testproject.
 
-    c:\projects>tf permission /allow:PendChange /group:testers$/testproject
+```
+c:\projects>tf permission /allow:PendChange /group:testers$/testproject
+```
 
 The following example enables user somealias to make pending changes to his local copy of $/testtproject/314.cs in his workspace.
 
-    c:\projects>tf permission /allow:PendChange /user:somealias $/testproject/314.cs.
+```
+c:\projects>tf permission /allow:PendChange /user:somealias $/testproject/314.cs.
+```
 
 The following example denies user somealias the ability to make pending changes to his local copy of $/testproject/1256.cs.
 
-    c:\projects>tf permission /deny:PendChange /user:somealias $/testproject/1256.cs
+```
+c:\projects>tf permission /deny:PendChange /user:somealias $/testproject/1256.cs
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/properties-or-info-command.md
+++ b/docs/repos/tfvc/properties-or-info-command.md
@@ -24,8 +24,11 @@ Displays information about items under version control.
 
 To use the **properties** command, you must have the **Read** permission set to **Allow** for all specified files and folders. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf properties [/collection:TeamProjectCollectionUrl] [/recursive] [/login:username,[password]]
-    itemspec [/version:versionspec] [/workspace] 
+```
+tf properties [/collection:TeamProjectCollectionUrl] [/recursive] [/login:username,[password]]
+itemspec [/version:versionspec] [/workspace] 
+```
+
 ## Parameters
 
 <table><thead>
@@ -104,11 +107,15 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example displays properties information about the file 314.cs.
 
-    c:\projects>tf properties 314.cs
+```
+c:\projects>tf properties 314.cs
+```
 
 The following example displays the properties of the working folder c:\\projects\\objects.
 
-    c:\projects>tf properties objects
+```
+c:\projects>tf properties objects
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/proxy-command.md
+++ b/docs/repos/tfvc/proxy-command.md
@@ -24,20 +24,31 @@ Configures your client computer to use a proxy server. Adds, deletes, and lists 
 
 To use the **proxy** command to configure a client computer, you must be a member of the **User** security group on the local computer. To use the **proxy** command to work with proxy records, you must have the AdminConfiguration permission. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf proxy ([/configure [Url]) [/collection:TeamProjectCollectionUrl]
-     [/login:UserName,[Password]]
+```
+tf proxy ([/configure [Url]) [/collection:TeamProjectCollectionUrl]
+[/login:UserName,[Password]]
+```
 
-    tf proxy /add Url [/name:Name] [/site:SiteName] 
-    [/description:Description] [/default:(global|site|all)] 
-    [/collection:TeamProjectCollectionUrl] [/login:UserName,[Password]] 
+```
+tf proxy /add Url [/name:Name] [/site:SiteName] 
+[/description:Description] [/default:(global|site|all)] 
+[/collection:TeamProjectCollectionUrl] [/login:UserName,[Password]] 
+```
 
-    tf proxy /delete Url [/collection:TeamProjectCollectionUrl]
-    [/login:UserName,[Password]] 
+```
+tf proxy /delete Url [/collection:TeamProjectCollectionUrl]
+[/login:UserName,[Password]] 
+```
 
-    tf proxy /list [Url1 Yrl2 ...] 
-    [/collection:TeamProjectCollectionUrl] [/login:UserName,[Password]]
+```
+tf proxy /list [Url1 Yrl2 ...] 
+[/collection:TeamProjectCollectionUrl] [/login:UserName,[Password]]
+```
 
-     tf proxy /enabled:(true|false)
+```
+tf proxy /enabled:(true|false)
+```
+
 ## Parameters
 
 <table><thead>
@@ -104,19 +115,27 @@ For more information about how to find the **tf** command-line utility, see [Tf 
 ## Examples
 The following example automatically detects and configures a client computer to use a proxy, if a proxy record has been established:
 
-    c:\projects>tf proxy /configure
+```
+c:\projects>tf proxy /configure
+```
 
 The following example overrides any proxy records on Team Foundation Server and configures a client computer to use a specified proxy:
 
-    c:\projects>tf proxy /configure Url
+```
+c:\projects>tf proxy /configure Url
+```
 
 The following example adds a global record to Team Foundation Server about the availability of this proxy. The first time that a developer performs a get operation, Team Foundation Server will redirect all requests from that developer to the specified proxy.
 
-    c:\projects>tf proxy /add http://server:8081 /default:global /collection:http://tfsserver:8080/
+```
+c:\projects>tf proxy /add http://server:8081 /default:global /collection:http://tfsserver:8080/
+```
 
 The following example adds a site record to Team Foundation Server for developers in an Active Directory domain, which is named corp, to use this proxy server. The first time that a developer from that domain performs a get operation, Team Foundation Server will redirect all requests from that developer to the specified proxy.
 
-    c:\projects>tf proxy /add http://server:8081 /default:site /site:corp /collection:http://tfsserver:8080/
+```
+c:\projects>tf proxy /add http://server:8081 /default:site /site:corp /collection:http://tfsserver:8080/
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/rename-command-team-foundation-version-control.md
+++ b/docs/repos/tfvc/rename-command-team-foundation-version-control.md
@@ -27,7 +27,9 @@ The **rename** command changes the name or the path of a file or folder. You can
 
 To use the **rename** command, you have the **Check out** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf rename [/lock:(none|checkout|checkin)] [/login:username,[password]] olditem newitem
+```
+tf rename [/lock:(none|checkout|checkin)] [/login:username,[password]] olditem newitem
+```
 
 ## Parameters<table>
 <thead>
@@ -109,15 +111,21 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example changes the name of 314.c to 1254.c.
 
-    c:\projects>tf rename  314.c  1254.c
+```
+c:\projects>tf rename  314.c  1254.c
+```
 
 The following example renames 314.c to 1254.c and moves it to the newdir folder.
 
-    c:\projects>tf rename 314.c ..\newdir\1254.c
+```
+c:\projects>tf rename 314.c ..\newdir\1254.c
+```
 
 The following example changes the name of Form1.vb to MainPage.vb and applies a lock to it.
 
-    c:\projects>tf rename Form1.vb MainPage.vb /lock:checkin
+```
+c:\projects>tf rename Form1.vb MainPage.vb /lock:checkin
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/resolve-command.md
+++ b/docs/repos/tfvc/resolve-command.md
@@ -24,9 +24,12 @@ Lets you resolve conflicts between changed items in your workspace and the lates
 
 To use the **resolve** command, you must be either the workspace owner or have the global **Administer workspaces** permission set to **Allow**. You must also have the **Read** and **Check out** permissions for the items involved in a resolve operation set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf resolve [itemspec] 
-    [/auto:(AutoMerge|TakeTheirs|KeepYours|OverwriteLocal|DeleteConflict|KeepYoursRenameTheirs)] 
-    [/preview] [(/overridetype:overridetype | /converttotype:converttype] [/recursive] [/newname:path] [/noprompt] [/login:username, [password]]
+```
+tf resolve [itemspec] 
+[/auto:(AutoMerge|TakeTheirs|KeepYours|OverwriteLocal|DeleteConflict|KeepYoursRenameTheirs)] 
+[/preview] [(/overridetype:overridetype | /converttotype:converttype] [/recursive] [/newname:path] [/noprompt] [/login:username, [password]]
+```
+
 ## Parameters
 
 <table>
@@ -150,11 +153,15 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example invokes the **Resolve Conflicts** dialog box so that you can tell Team Foundation Server how to deal with pending changes that conflict with the server version.
 
-    tf resolve
+```
+tf resolve
+```
 
 The following example attempts to resolve all conflicts by automatically merging the changes.
 
-    tf resolve /auto:automerge
+```
+tf resolve /auto:automerge
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/rollback-command-team-foundation-version-control.md
+++ b/docs/repos/tfvc/rollback-command-team-foundation-version-control.md
@@ -24,13 +24,14 @@ You can use this command to roll back the effects of one or more changesets to o
 
 To use this command, you must have the **Read**, **Check Out**, and **Check In** permissions set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-	tf rollback /toversion:VersionSpec ItemSpec [/recursive] [/lock:none|checkin|checkout] [/version:versionspec] [/keepmergehistory] [/login:username,[password]] [/noprompt]
+```
+tf rollback /toversion:VersionSpec ItemSpec [/recursive] [/lock:none|checkin|checkout] [/version:versionspec] [/keepmergehistory] [/login:username,[password]] [/noprompt]
+```
 
-&nbsp;
-
-	tf rollback /changeset:ChangesetFrom~ChangesetTo [ItemSpec] [/recursive] [/lock:none|checkin|checkout] [/version:VersionSpec]
-	[/keepmergehistory] [/noprompt] [/login:username,[password]]
-
+```
+tf rollback /changeset:ChangesetFrom~ChangesetTo [ItemSpec] [/recursive] [/lock:none|checkin|checkout] [/version:VersionSpec]
+[/keepmergehistory] [/noprompt] [/login:username,[password]]
+```
 
 ## Parameters
 
@@ -112,19 +113,28 @@ The exit codes in the following table appear after you run the **tf rollback** c
 ## Examples
 The following example negates the effect of changeset **23** on all items that were changed in that changeset.
 
-    c:\workspace> tf rollback /changeset:C23
+```
+c:\workspace> tf rollback /changeset:C23
+```
 
 The following example negates the effect of changeset 23 on the file **a.txt**.
 
-    c:\workspace> tf rollback /changeset:C23 a.txt
+```
+c:\workspace> tf rollback /changeset:C23 a.txt
+```
 
 The following example changes the content of **a.txt** to match the version that was checked in with changeset 23.
 
-    c:\workspace> tf rollback /toversion:C23 a.txt
+```
+c:\workspace> tf rollback /toversion:C23 a.txt
+```
 
 The following example changes the content of **OurTeamProject** to match the last changeset that was applied on or before midnight on August 31, 2009.
 
-    c:\workspace> tf rollback /toversion:D08/31/2009 /recursive $/OurTeamProject/
+```
+c:\workspace> tf rollback /toversion:D08/31/2009 /recursive $/OurTeamProject/
+```
+
 ## Example: /keepmergehistory Option
 When you roll back a changeset that includes a branch or a merge change, you usually want future merges between the same source and the same target to include those changes. However, you can use the **/keepmergehistory** option if you want future merges between the same source and the same target to exclude changesets that were encompassed in a past merge operation.
 
@@ -132,7 +142,9 @@ For example, you can use this command in the following situation:
 
 1.  In On June 30, 2009, you perform a full merge of all items from **$/BranchA/** to **$/BranchB/**:
 
-		c:\workspace> tf merge $/BranchA $/BranchB
+    ```
+	c:\workspace> tf merge $/BranchA $/BranchB
+    ```
 
     You check in this merge as part of changeset 292.
 
@@ -140,7 +152,9 @@ For example, you can use this command in the following situation:
 
 3.  On August 1, 2009, you merge **$/BranchA/Util.cs** to **$/BranchB/Util.cs**:
 
-		c:\workspace> tf merge $/BranchA/Util.cs $/BranchB/Util.cs
+    ```
+	c:\workspace> tf merge $/BranchA/Util.cs $/BranchB/Util.cs
+    ```
 
     You check in the change as part of changeset 314. The result of this operation is that the edits that you made in changesets 297, 301, and 305 to **$/BranchA/Util.cs** are now also applied to **$/BranchB/Util.cs**.
 
@@ -148,15 +162,21 @@ For example, you can use this command in the following situation:
 
     -   If you want the changes that you made in July to **$/BranchA/Util.cs** to be re-applied to **$/BranchB/Util.cs** in future merges, you should type the following command:
 
-			c:\workspace> tf rollback /changeset:314
+        ```
+		c:\workspace> tf rollback /changeset:314
+        ```
 
     -   If you want the changes that you made in July to **$/BranchA/Util.cs** to never be re-applied to **$/BranchB/Util.cs** in future merges, you should type the following command:
 
-			c:\workspace> tf rollback /changeset:314 /keepmergehistory
+        ```
+    	c:\workspace> tf rollback /changeset:314 /keepmergehistory
+        ```
 
 5.  A few weeks later, you merge **$/BranchA/** into **$/BranchB/**:
 
-		c:\workspace> tf merge $/BranchA $/BranchB
+    ```
+	c:\workspace> tf merge $/BranchA $/BranchB
+    ```
 
     -   If you omitted the **/keepmergehistory** option, the **merge** change will apply to **$/BranchB/Util.cs** all changesets that were applied to **$/BranchA/Util.cs** since changeset 292, including changesets 297, 301, 305. In other words, a future merge will undo the **rollback** change.
 

--- a/docs/repos/tfvc/shelve-command.md
+++ b/docs/repos/tfvc/shelve-command.md
@@ -24,12 +24,18 @@ Stores a set of pending changes, together with pending check-in notes, a comment
 
 If you want to use the **shelve** command to delete a shelveset, you must be a shelveset owner, or your **Administer shelved changes** permission must be set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf shelve  [/replace] [/comment:("comment"|@commentfile)] [shelvesetname] [/validate][/noprompt] [/login:username,[password]]
+```
+tf shelve  [/replace] [/comment:("comment"|@commentfile)] [shelvesetname] [/validate][/noprompt] [/login:username,[password]]
+```
 
-    tf shelve [/move] [/replace] [/comment:("comment"|@commentfile)] 
-    [/recursive] [shelvesetname] itemspec [/validate] [/noprompt] [/login:username,[password]]
+```
+tf shelve [/move] [/replace] [/comment:("comment"|@commentfile)] 
+[/recursive] [shelvesetname] itemspec [/validate] [/noprompt] [/login:username,[password]]
+```
 
-    tf shelve /delete shelvesetname[;owner] [/login:username,[password]] [/collection:TeamProjectCollectionUrl]
+```
+tf shelve /delete shelvesetname[;owner] [/login:username,[password]] [/collection:TeamProjectCollectionUrl]
+```
 
 ## Parameters
 
@@ -82,19 +88,27 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 
 The following example creates a new shelveset on the Team Foundation Server called Reflector\_BuddyTest, assigns ownership to the user Hans, then returns all items in the current workspace to the latest version downloaded during the last **get** operation, and a sets a read-only state.
 
-    c:\projects> tf shelve Reflector_BuddyTest;Hans /move
+```
+c:\projects> tf shelve Reflector_BuddyTest;Hans /move
+```
 
 The following example deletes the existing shelveset, "new-feature" from the server, creates a new shelveset by that name, and retains all pending changes in the current workspace.
 
-    c:\projects> tf shelve new-feature /replace
+```
+c:\projects> tf shelve new-feature /replace
+```
 
 The following example creates a shelveset named HelloWorld\_TestMe that includes all pending changes to all .cs files in the C:\\projects working folder and its subfolders.
 
-    c:\projects> tf shelve HelloWorld_TestMe c:\projects\*.cs /recursive
+```
+c:\projects> tf shelve HelloWorld_TestMe c:\projects\*.cs /recursive
+```
 
 The following example deletes the HelloWorld\_24 shelveset.
 
-    c:\projects> tf shelve HelloWorld_24 /delete
+```
+c:\projects> tf shelve HelloWorld_24 /delete
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/shelvesets-command.md
+++ b/docs/repos/tfvc/shelvesets-command.md
@@ -24,7 +24,10 @@ Displays information about a set of shelved changes.
 
 To use the **shelvesets** command, you must the have **Read** permission and the **Check out** permission set to **Allow** for the items in the shelvesets. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf shelvesets [/owner:ownername] [/format:(brief|detailed)] [/collection:TeamProjectCollectionUrl]] [/login:username,[password]] shelvesetname
+```
+tf shelvesets [/owner:ownername] [/format:(brief|detailed)] [/collection:TeamProjectCollectionUrl]] [/login:username,[password]] shelvesetname
+```
+
 ## Parameters<table>
 
 |**Argument**|**Description**|
@@ -54,15 +57,21 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 
 The following example displays information about the BuddyTest\_23 shelveset for the Team Foundation Server to which the current directory maps.
 
-    c:\projects>tf shelvesets BuddyTest_23
+```
+c:\projects>tf shelvesets BuddyTest_23
+```
 
 The following example lists the shelvesets owned by "John."
 
-    c:\projects>tf shelvesets /owner:John
+```
+c:\projects>tf shelvesets /owner:John
+```
 
 The following example displays information about the shelvesets on the Team Foundation Server to which the current directory maps.
 
-    c:\projects>tf shelvesets /owner:*
+```
+c:\projects>tf shelvesets /owner:*
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/status-command.md
+++ b/docs/repos/tfvc/status-command.md
@@ -22,12 +22,14 @@ Displays information about pending changes to files and folders in one or more w
 
 **Requirements:** See [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf stat[us] itemspec [/collection:TeamProjectCollectionUrl]
-    [/login:username,[password]]
-    ([/workspace:workspacename[;workspaceowner]] 
-    | [/shelveset:shelvesetname[;shelvesetowner]])
-    [/format:(brief|detailed)] [/recursive][/user:(*|username)]
-    [/nodetect]
+```
+tf stat[us] itemspec [/collection:TeamProjectCollectionUrl]
+[/login:username,[password]]
+([/workspace:workspacename[;workspaceowner]] 
+| [/shelveset:shelvesetname[;shelvesetowner]])
+[/format:(brief|detailed)] [/recursive][/user:(*|username)]
+[/nodetect]
+```
 
 ## Parameters
 
@@ -81,19 +83,25 @@ In all the following examples, assume that `$/SiteApp/Main/` is mapped to `c:\\c
 
 ### List all changes in the current workspace
 
-    c:\code\SiteApp\Main\SolutionA\>tf stat
+```
+c:\code\SiteApp\Main\SolutionA\>tf stat
+```
 
 Lists all pending changes in the workspace.
 
 ### List all changes in a folder
 
-    c:\code\SiteApp\Main>tf stat SolutionA\*
+```
+c:\code\SiteApp\Main>tf stat SolutionA\*
+```
 
 Lists all pending changes to all items in the SolutionA folder.
 
 ### List all changes in a folder and its subfolders
 
-    c:\code\SiteApp\Main>tf stat SolutionA\* /recursive
+```
+c:\code\SiteApp\Main>tf stat SolutionA\* /recursive
+```
 
 Lists pending changes to all items in the SolutionA folder, including those in its subfolders).
 

--- a/docs/repos/tfvc/undelete-command.md
+++ b/docs/repos/tfvc/undelete-command.md
@@ -27,8 +27,11 @@ The **undelete** command restores items that were previously deleted.
 
 To use the **undelete** command, you must have the **Check out** permission set to **Allow**. If you include the **/lock** option with a value other than none, you must have the **Lock** permission set to **Allow**. Additionally, you must own the workspace or have the global **Administer workspaces** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf undelete [/noget] [/lock:(none|checkin|checkout)] 
-    [/recursive] itemspec[;deletionID] [/login:username,[password]]
+```
+tf undelete [/noget] [/lock:(none|checkin|checkout)] 
+[/recursive] itemspec[;deletionID] [/login:username,[password]]
+```
+
 ## Parameters
 
 | **Argument** |                                                                                                                 **Description**                                                                                                                 |
@@ -66,20 +69,28 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example restores 314.cs to the server folder from which 314.cs was deleted and retrieves a read-only copy of the latest version in the current workspace.
 
-    C:\projects>tf undelete c:\math\314.cs
+```
+C:\projects>tf undelete c:\math\314.cs
+```
 
 The following example displays deletion IDs for all items on the server that have been deleted more than one time.
 
-    c:\projects>tf dir $/ /deleted
+```
+c:\projects>tf dir $/ /deleted
+```
 
 -   Sample output:
 
-		$/projects/math/314.cs;X10
-        $/projects/math/314.cs;X11
+    ```
+	$/projects/math/314.cs;X10
+	$/projects/math/314.cs;X11
+    ```
 
 The following example restores the X11 version of 314.cs to the server folder from which the file was deleted and retrieves a read-only copy of the latest version in the current workspace.
 
-    c:\projects>tf undelete 314.cs;X11
+```
+c:\projects>tf undelete 314.cs;X11
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/undo-command.md
+++ b/docs/repos/tfvc/undo-command.md
@@ -22,9 +22,11 @@ Discards one or more pending changes to files or folders.
 
 **Requirements:** See [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf undo [/workspace:workspacename[;workspaceowner]]
-    [/recursive] itemspec [/noprompt] [/login:username,[password]]
-    [/collection:TeamProjectCollectionUrl]
+```
+tf undo [/workspace:workspacename[;workspaceowner]]
+[/recursive] itemspec [/noprompt] [/login:username,[password]]
+[/collection:TeamProjectCollectionUrl]
+```
 
 ## Parameters
 
@@ -64,20 +66,26 @@ The **undo** command removes any [locks](work-version-control-locks.md) on the i
 
 ### Remove pending changes to a file
 
-    c:\code\SiteApp\Main\SolutionA\Project1>tf undo program.cs
+```
+c:\code\SiteApp\Main\SolutionA\Project1>tf undo program.cs
+```
 
 Removes all pending changes to program.cs.
 
 ### Recursively remove pending changes to all items in a folder
 
-    c:\code\SiteApp\Main>tf undo * /recursive
+```
+c:\code\SiteApp\Main>tf undo * /recursive
+```
 
 Removes all pending changes in the c:\\code\\SiteApp\\Main folder and all its subfolders.
 
 ### Remove pending changes to a file in a remote workspace
 
-    c:\>tf undo /collection:http://fabrikam-3:8080/tfs/DefaultCollection
-    /workspace:FABRIKAM-1;JuliaI $/SiteApp/Main/SolutionA/Project1/program.cs
+```
+c:\>tf undo /collection:http://fabrikam-3:8080/tfs/DefaultCollection
+/workspace:FABRIKAM-1;JuliaI $/SiteApp/Main/SolutionA/Project1/program.cs
+```
 
 Removes all pending changes to program.cs in the specified collection and workspace.
 

--- a/docs/repos/tfvc/unlabel-command.md
+++ b/docs/repos/tfvc/unlabel-command.md
@@ -24,7 +24,9 @@ Removes an item from an existing label in the server for Team Foundation version
 
 To use the **unlabel** command, you must either own the label, or have the **Administer labels** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf unlabel [/collection:TeamProjectCollectionUrl] [/recursive] [/login:username, [password]] labelname itemspec
+```
+tf unlabel [/collection:TeamProjectCollectionUrl] [/recursive] [/login:username, [password]] labelname itemspec
+```
 
 ## Parameters
 
@@ -83,11 +85,15 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 
 The following example removes the "goodbuild" label from 314.cs.
 
-    c:\projects>tf unlabel goodbuild $/src/314.cs
+```
+c:\projects>tf unlabel goodbuild $/src/314.cs
+```
 
 The following example removes the "Beta1" label from all files and folders in the collection at http://myserver:8080/tfs/DefaultCollection.
 
-    c:\projects>tf unlabel Beta1 $/ /collection:http://myserver:8080/tfs/DefaultCollection /recursive
+```
+c:\projects>tf unlabel Beta1 $/ /collection:http://myserver:8080/tfs/DefaultCollection /recursive
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/unshelve-command.md
+++ b/docs/repos/tfvc/unshelve-command.md
@@ -24,8 +24,11 @@ Restores shelved file revisions, check-in notes, comments, and work item associa
 
 To use the **unshelve** command, you must have the **Read** permission set to **Allow**, and you must have the **Check out** permission for the items in the shelveset set to **Allow**. Additionally, to delete a shelveset, you must be its owner or have the **Administer shelved changes** global permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf unshelve [/move] [shelvesetname[;username]] itemspec 
-    [/recursive] [/noprompt][/login:username,[password]]
+```
+tf unshelve [/move] [shelvesetname[;username]] itemspec 
+[/recursive] [/noprompt][/login:username,[password]]
+```
+
 ## Parameters<table>
 <thead>
 <tr>
@@ -116,11 +119,15 @@ You can delete a shelveset by using `tf shelve /delete`. For more information, s
 ## Examples
 The following example opens the **Unshelve** dialog box so that you can find and unshelve a shelveset into the current workspace. You also have an option in the dialog box to have the shelveset deleted when the unshelve operation completes.
 
-    c:\>tf unshelve
+```
+c:\>tf unshelve
+```
 
 The following example unshelves the shelveset buddytest\_1256 into the current workspace and removes it from Team Foundation Server.
 
-    c:\>tf unshelve /move buddytest_1256
+```
+c:\>tf unshelve /move buddytest_1256
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/use-team-foundation-version-control-commands.md
+++ b/docs/repos/tfvc/use-team-foundation-version-control-commands.md
@@ -28,8 +28,9 @@ To launch the Visual Studio command prompt, from Windows **Start**, choose **Vis
 
 In most cases, you run the version control command in the context of a directory that is mapped in the workspace. For example, `$/SiteApp/Main/` is mapped to `c:\\code\\SiteApp\\Main\\`. To get the latest version of all items in the workspace:
 
-    c:\code\SiteApp\Main\SolutionA>tf get
-
+```
+c:\code\SiteApp\Main\SolutionA>tf get
+```
 
 ### Set up your dev machine and manage workspaces
 
@@ -204,7 +205,9 @@ Some commands support shortcuts. For example, you can call the [Delete command](
 
 For example, the [Checkout command](checkout-or-edit-command.md):
 
-    tf checkout [/lock:( none|checkin|checkout)] [/recursive] itemspec [/login: username,[ password]]
+```
+tf checkout [/lock:( none|checkin|checkout)] [/recursive] itemspec [/login: username,[ password]]
+```
 
 Let's review the arguments from this example:
 
@@ -238,15 +241,19 @@ A server itemspec argument specifies a path to items on your Team Foundation Ser
 
 You typically use server itemspec arguments when you need run a command on items not on the client machine. For example, you are working on a dev machine and need to get some revision history data about some items that are in a project collection you don't work in:
 
-    c:\>tf history /collection:http://fabrikam-3:8080/tfs/DefaultCollection
-    $/SiteApp/Main/SolutionA/Project1/* /recursive  
-    /noprompt 
+```
+c:\>tf history /collection:http://fabrikam-3:8080/tfs/DefaultCollection
+$/SiteApp/Main/SolutionA/Project1/* /recursive  
+/noprompt 
+```
 
 #### Multiple itemspec arguments
 
 For some commands, you can specify multiple *itemspec* arguments. For example:
 
-    c:\code\SiteApp\Main\SolutionA\Project1\>tf checkout program1.cs program2.c
+```
+c:\code\SiteApp\Main\SolutionA\Project1\>tf checkout program1.cs program2.c
+```
 
 Checks out program.cs and program2.c.
 
@@ -260,7 +267,9 @@ You use a *versionspec* (version specification) to specify the version of items 
 
 When you use the [History command](history-command.md) or the [Difference Command](difference-command.md), you can specify a range of versions by separating the versions with a tilde (~). For example:
 
-    c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D4/12/2012~D4/24/2012
+```
+c:\code\SiteApp\Main\SolutionA>tf history /noprompt * /recursive /v:D4/12/2012~D4/24/2012
+```
 
 Use the following syntax to specify a *versionspec*.
 
@@ -412,11 +421,15 @@ Use the **/login** option to specify the Team Foundation Server user account to 
 
 For example, Julia is working with Peter at his dev machine. She uses the [Lock command](lock-command.md) to unlock a file that she locked earlier:
 
-    c:\code\SiteApp\Main> tf lock /lock:none program.cs /login:JuliaI,JuliaPassword
+```
+c:\code\SiteApp\Main> tf lock /lock:none program.cs /login:JuliaI,JuliaPassword
+```
 
 If she wants to avoid having her password appear in the command prompt, she can enter the command without the password:
 
-    c:\code\SiteApp\Main> tf lock /lock:none program.cs /login:JuliaI
+```
+c:\code\SiteApp\Main> tf lock /lock:none program.cs /login:JuliaI
+```
 
 After she enters this command, the system then prompts her to type her password in a dialog box that masks her input.
 
@@ -437,7 +450,9 @@ After she enters this command, the system then prompts her to type her password 
 
 Use the **/lock** option to apply or remove a lock at the same time you run another command such as [Add](add-command.md) or [Edit](checkout-or-edit-command.md).
 
-    /lock:(none|checkin|checkout)
+```
+/lock:(none|checkin|checkout)
+```
 
 -   **None**: No lock is placed on an item. If a lock is already in place, it is removed.
 
@@ -569,6 +584,8 @@ Version control commands return the following exit codes:
 
 For example:
 
-    c:\code\SiteApp\Main\SolutionA\Project1\>tf checkout program1.cs program2.c
+```
+c:\code\SiteApp\Main\SolutionA\Project1\>tf checkout program1.cs program2.c
+```
 
 If one of the files you are trying to check out does not exist on the server, the command returns **1** to indicate partial success.

--- a/docs/repos/tfvc/view-command.md
+++ b/docs/repos/tfvc/view-command.md
@@ -24,9 +24,12 @@ The **view** command retrieves a specific version of a file to a temporary folde
 
 To use the **view** command, you must have the **Read** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf view [/collection:TeamProjectCollectionUrl] [/console] [/recursive] [/output:localfile]
-    [/shelveset:shelvesetname[;owner]] [/noprompt] itemspec 
-    [/version:versionspec] [/login:username,[password]]
+```
+tf view [/collection:TeamProjectCollectionUrl] [/console] [/recursive] [/output:localfile]
+[/shelveset:shelvesetname[;owner]] [/noprompt] itemspec 
+[/version:versionspec] [/login:username,[password]]
+```
+
 ## Parameters<table>
 <thead>
 <tr>
@@ -133,19 +136,27 @@ Finally, you can redirect the contents of a file to standard out using **|** or 
 ## Examples
 The following example displays the latest version of the file 314.c.
 
-    c:\projects>tf view 314.c
+```
+c:\projects>tf view 314.c
+```
 
 The following example displays the version of 314.c that was checked in with changeset 1999.
 
-    c:\projects>tf view /version:C1999 314.c
+```
+c:\projects>tf view /version:C1999 314.c
+```
 
 The following example retrieves version 5 of 314.c and writes it to the file 314.old.
 
-    c:\projects>tf view /version:5 314.c > 314.old
+```
+c:\projects>tf view /version:5 314.c > 314.old
+```
 
 The following example displays the latest version of each file that matches the wildcard "\*.cs".
 
-    c:\projects>tf view *.cs
+```
+c:\projects>tf view *.cs
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/workfold-command.md
+++ b/docs/repos/tfvc/workfold-command.md
@@ -24,24 +24,38 @@ Creates, modifies, or displays information about the mappings between your works
 
 To use the **workfold** command, you must be the owner of the specified or implied workspace or have the global **Administer workspaces** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf workfold localfolder [/login:username,[password]]
+```
+tf workfold localfolder [/login:username,[password]]
+```
 
-    tf workfold [/workspace:workspacename] [/login:username,[password]]
+```
+tf workfold [/workspace:workspacename] [/login:username,[password]]
+```
 
-    tf workfold [/collection:TeamProjectCollectionUrl] [/workspace:workspacename] [/login:username,[password]]
-    serverfolder
+```
+tf workfold [/collection:TeamProjectCollectionUrl] [/workspace:workspacename] [/login:username,[password]]
+serverfolder
+```
 
-    tf workfold [/map serverfolder localfolder] [/collection:TeamProjectCollectionUrl] 
-    [/workspace:workspacename][/login:username,[password]
+```
+tf workfold [/map serverfolder localfolder] [/collection:TeamProjectCollectionUrl] 
+[/workspace:workspacename][/login:username,[password]
+```
 
-    tf workfold /unmap [/collection:TeamProjectCollectionUrl] [/workspace:workspacename] 
-    [/recursive] (serverfolder|localfolder) [/login:username,[password]]
+```
+tf workfold /unmap [/collection:TeamProjectCollectionUrl] [/workspace:workspacename] 
+[/recursive] (serverfolder|localfolder) [/login:username,[password]]
+```
 
-    tf workfold /cloak 
-    serverfolder [/workspace:workspacename] [/collection:TeamProjectCollectionUrl] [/login:username,[password]]
+```
+tf workfold /cloak 
+serverfolder [/workspace:workspacename] [/collection:TeamProjectCollectionUrl] [/login:username,[password]]
+```
 
-    tf workfold /decloak serverfolder
-    [/workspace:workspacename] [/collection:TeamProjectCollectionUrl][/login:username,[password]]
+```
+tf workfold /decloak serverfolder
+[/workspace:workspacename] [/collection:TeamProjectCollectionUrl][/login:username,[password]]
+```
 
 ## Parameters<table>
 <thead>
@@ -134,11 +148,15 @@ By default, workspace mappings are applied recursively. When you map a local fol
 
 In this example, you can use a wildcard, "\*", to map a server folder and its immediate items to your local workspace:
 
-    tf workfold $/projects/MyTeamProject/* C:\MyLocalWorkfold\MyTeamProject
+```
+tf workfold $/projects/MyTeamProject/* C:\MyLocalWorkfold\MyTeamProject
+```
 
 In this example, you can override the automatically-created mapping between $/projects/project\_one and C:\\projects\\project\_one by using the **workfold** command as follows:
 
-    tf workfold $/projects/project_one C:\DifferentWorkfold
+```
+tf workfold $/projects/project_one C:\DifferentWorkfold
+```
 
 ### Mappings under Cloaks
 
@@ -147,19 +165,27 @@ Mappings of uncloaked folders that are located beneath a cloaked folder in the v
 ## Examples
 The following example displays the mappings for the workspace in which c:\\projects resides.
 
-    c:\projects>tf workfold
+```
+c:\projects>tf workfold
+```
 
 The following example cloaks the c:\\projects\\lib folder.
 
-    c:\projects>tf workfold /cloak c:\projects\lib
+```
+c:\projects>tf workfold /cloak c:\projects\lib
+```
 
 The following example displays the mapping for the local file word.cs.
 
-    c:\projects>tf workfold word.cs
+```
+c:\projects>tf workfold word.cs
+```
 
 The following example maps the folder C:\\DifferentWorkfold to the Team Foundation version control server folder $/projects/project\_one and replaces the previous workspace mapping for the $/projects/project\_one Team Foundation version control server folder.
 
-    c:\projects>tf workfold $/projects/project_one C:\DifferentWorkfold
+```
+c:\projects>tf workfold $/projects/project_one C:\DifferentWorkfold
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/workspace-command.md
+++ b/docs/repos/tfvc/workspace-command.md
@@ -23,17 +23,23 @@ Lets you create, delete, view, or modify properties and mappings associated with
 **Required Permissions**  
 To modify or delete an existing workspace, you must be the owner or have the global **Administer workspaces** permission set to **Allow**. To create a workspace, you must have the global **Create a workspace** permission set to **Allow**. To create workspaces for other users, you must have the **Administer workspaces** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf workspace /new [/noprompt] [/template:workspacename[;workspaceowner]]
-     [/computer:computername] [/comment:("comment"|@comment file)]
-     [workspacename[;workspaceowner]] [/login:username,[password]]
-     [/collection:TeamProjectCollectionUrl] [/permission:(Private|PublicLimited|Public)]
-     [/location:(local|server)]
-     
-    tf workspace /delete [/collection:TeamProjectCollectionUrl] workspacename[;workspaceowner] [/login:username,[password]]
+```
+tf workspace /new [/noprompt] [/template:workspacename[;workspaceowner]]
+[/computer:computername] [/comment:("comment"|@comment file)]
+[workspacename[;workspaceowner]] [/login:username,[password]]
+[/collection:TeamProjectCollectionUrl] [/permission:(Private|PublicLimited|Public)]
+[/location:(local|server)]
+```
 
-    tf workspace [/collection:TeamProjectCollectionUrl] [/comment: ("comment"|@comment file)] [/newname:workspacename]
-    [workspacename[;workspaceowner]] [/newowner:ownername] [/computer:computername] [/permission:(Private|PublicLimited|Public)] [/login:username,[password]]
-    [/location:(local|server)]
+```
+tf workspace /delete [/collection:TeamProjectCollectionUrl] workspacename[;workspaceowner] [/login:username,[password]]
+```
+
+```
+tf workspace [/collection:TeamProjectCollectionUrl] [/comment: ("comment"|@comment file)] [/newname:workspacename]
+[workspacename[;workspaceowner]] [/newowner:ownername] [/computer:computername] [/permission:(Private|PublicLimited|Public)] [/login:username,[password]]
+[/location:(local|server)]
+```
 
 ## Parameters
 
@@ -103,27 +109,39 @@ If no workspace specification is provided, the workspace for the current folder 
 
 The following example opens the **Add Workspace** dialog box and creates a new workspace. You can use the **Add Workspace** dialog box to edit the source control folder, owner, computer, comment, and local folders.
 
-    c:\projects>tf workspace /new /collection:http://myserver:8080/tfs/DefaultCollection
+```
+c:\projects>tf workspace /new /collection:http://myserver:8080/tfs/DefaultCollection
+```
 
 The following example creates a new workspace called Beta1 and assigns jenh as the workspace owner. You must have the AdminWorkspaces permission to assign ownership of a new workspace to another user. For more information on security permissions, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    c:\projects>tf workspace /new Beta1;jenh
+```
+c:\projects>tf workspace /new Beta1;jenh
+```
 
 The following example creates a new workspace by using the Beta1 workspace that is owned by jenh as a template.
 
-    c:\projects>tf workspace /new /template:Beta1;jenh /collection:http://myserver:8080/tfs/DefaultCollection
+```
+c:\projects>tf workspace /new /template:Beta1;jenh /collection:http://myserver:8080/tfs/DefaultCollection
+```
 
 The following example removes the Beta1 workspace from the server.
 
-    c:\projects>tf workspace /delete Beta1
+```
+c:\projects>tf workspace /delete Beta1
+```
 
 The following example edits properties for the current workspace.
 
-    c:\projects>tf workspace
+```
+c:\projects>tf workspace
+```
 
 The following example opens the Beta1 workspace for which user jenh is the owner so that you can see its properties and mappings. If you have the AdminWorkspaces permissions, you can change the workspace properties and mappings.
 
-    c:\projects> tf workspace Beta1;jenh
+```
+c:\projects> tf workspace Beta1;jenh
+```
 
 ## See Also
 

--- a/docs/repos/tfvc/workspaces-command.md
+++ b/docs/repos/tfvc/workspaces-command.md
@@ -23,13 +23,17 @@ Displays information about workspaces in the system and updates cached informati
 **Required Permissions**  
 To use the **workspaces** command, you must have the **Read** permission set to **Allow**. For more information, see [Permissions and groups reference](../../organizations/security/permissions.md).
 
-    tf workspaces [/owner:ownername] [/computer:computername] 
-    [/collection:TeamProjectCollectionUrl] [/format:(brief|detailed)] 
-    [/updateUserName:oldUserName] [/updateComputerName:oldComputerName] 
-    [workspacename][/login:username,[password]]
+```
+tf workspaces [/owner:ownername] [/computer:computername] 
+[/collection:TeamProjectCollectionUrl] [/format:(brief|detailed)] 
+[/updateUserName:oldUserName] [/updateComputerName:oldComputerName] 
+[workspacename][/login:username,[password]]
+```
 
-    tf workspaces /remove:(*|workspace1[,workspace2,...]) 
-    /collection:(*|TeamProjectCollectionUrl)
+```
+tf workspaces /remove:(*|workspace1[,workspace2,...]) 
+/collection:(*|TeamProjectCollectionUrl)
+```
 
 ## Parameters
 
@@ -124,23 +128,33 @@ For more information on how to find the **tf** command-line utility, see [Tf Com
 ## Examples
 The following example displays a list of all workspaces for the current user on the current computer.
 
-    c:\projects>tf workspaces
+```
+c:\projects>tf workspaces
+```
 
 The following example displays the list of all workspaces for all users on all computers that have been created in the following project collection at the address http://myserver:8080/tfs/DefaultCollection.
 
-    c:\projects>tf workspaces /owner:* /computer:* /collection:http://myserver:8080/tfs/DefaultCollection
+```
+c:\projects>tf workspaces /owner:* /computer:* /collection:http://myserver:8080/tfs/DefaultCollection
+```
 
 The following example displays detailed information about all workspaces that the current user has created in the project collection at the address http://myserver:8080/tfs/DefaultCollection.
 
-    c:\projects>tf workspaces /computer:* /format:detailed /collection:http://myserver:8080/tfs/DefaultCollection
+```
+c:\projects>tf workspaces /computer:* /format:detailed /collection:http://myserver:8080/tfs/DefaultCollection
+```
 
 The following example displays detailed information including a list of workspace mappings about the workspace "WS1," which is owned by the current user and is located on the current computer.
 
-    c:\projects>tf workspaces /format:detailed /collection:http://myserver:8080/tfs/DefaultCollection WS1
+```
+c:\projects>tf workspaces /format:detailed /collection:http://myserver:8080/tfs/DefaultCollection WS1
+```
 
 The following example removes all cached workspaces from the cache in the project collection at the address http://myserver:8080/tfs/DefaultCollection.
 
-    c:\projects>tf workspaces /remove:* /collection:http://myserver:8080/tfs/DefaultCollection
+```
+c:\projects>tf workspaces /remove:* /collection:http://myserver:8080/tfs/DefaultCollection
+```
 
 ## See Also
 


### PR DESCRIPTION

Ensure consistent fended code block style.
The implicit indent fences sometimes accidentally swallow content not intended as code blocks.