### PR TITLE
Subdirectories are included in a publish build artifact

### DIFF
--- a/docs/pipelines/tasks/utility/publish-build-artifacts.md
+++ b/docs/pipelines/tasks/utility/publish-build-artifacts.md
@@ -39,7 +39,7 @@ None
 
 | Argument | Description |
 | -------- | ----------- |
-| Path to publish | Path to the folder or file you want to publish. The path must be a fully-qualified path or a valid path relative to the root directory of your repository. (`$(Build.ArtifactStagingDirectory)`) is the most common value and is what should be used in most cases. Subdirectories of the specified path will not be published. Wildcards in the path are not supported. See [Artifacts in Azure Pipelines](../../build/artifacts.md). |
+| Path to publish | Path to the folder or file you want to publish. The path must be a fully-qualified path or a valid path relative to the root directory of your repository. (`$(Build.ArtifactStagingDirectory)`) is the most common value and is what should be used in most cases. Subdirectories of the specified path will be included. Wildcards in the path are not supported. See [Artifacts in Azure Pipelines](../../build/artifacts.md). |
 | Artifact name | Specify the name of the artifact that you want to create. It can be whatever you want. For example: `drop` |
 | Artifact publish location | In most cases, Azure Pipelines/TFS (`Server` on **TFS 2018 RTM** and older) is the best and simplest option. Otherwise, choose a file share and then specify a few more arguments (see below). If left empty or `container` is specified, it will have the same effect as specifying `Azure Pipelines/TFS`. To learn more, see [Artifacts in Azure Pipelines](../../artifacts/build-artifacts.md). |
 | File share path | Specify the path to the file share where you want to copy the files. The path must be a fully-qualified path or a valid path relative to the root directory of your repository. Publishing artifacts from a Linux or macOS agent to a file share is not supported. |


### PR DESCRIPTION
Change the text of 'Path to publish' since it also includes subdirectories.