### PR TITLE
Adding TCM Microservice URL to the Proxy/Firewall bypass list

### DIFF
--- a/docs/pipelines/agents/_shared/v2/qa-firewall.md
+++ b/docs/pipelines/agents/_shared/v2/qa-firewall.md
@@ -13,6 +13,7 @@ https://login.microsoftonline.com
 https://app.vssps.visualstudio.com 
 https://{organization_name}.visualstudio.com
 https://{organization_name}.vsrm.visualstudio.com
+https://{organization_name}.vstmr.visualstudio.com
 https://{organization_name}.pkgs.visualstudio.com
 https://{organization_name}.vssps.visualstudio.com
 ```

--- a/docs/pipelines/agents/_shared/v2/web-proxy-bypass.md
+++ b/docs/pipelines/agents/_shared/v2/web-proxy-bypass.md
@@ -13,6 +13,7 @@ https://login.microsoftonline.com
 https://app.vssps.visualstudio.com 
 https://{organization_name}.visualstudio.com
 https://{organization_name}.vsrm.visualstudio.com
+https://{organization_name}.vstmr.visualstudio.com
 https://{organization_name}.pkgs.visualstudio.com
 https://{organization_name}.vssps.visualstudio.com
 ```


### PR DESCRIPTION
Test Reporting service (TCM) is a new micro service. We have heard from customers who are hosting the agent behind firewall and using the old URL(visulstudio.com) then need to whitelist/bypass the mentioned URL inorder to publish the test results from your agent.