### PR TITLE
DownloadPipelineArtifactV2 - Adding aliases for parameters

### DIFF
--- a/docs/pipelines/tasks/utility/download-pipeline-artifact.md
+++ b/docs/pipelines/tasks/utility/download-pipeline-artifact.md
@@ -28,19 +28,19 @@ Use this task in a build or release pipeline to download pipeline artifacts from
 ## Arguments
 
 
-| Argument | Description |
-| -------- | ----------- |
-| `buildType`<br/>Download artifacts produced by | Download artifacts produced by the current pipeline run, or from a specific pipeline run.<br/>Options: `current`, `specific` |
-| `specificBuildWithTriggering`<br/>When appropriate, download artifacts from the triggering build | A boolean specifying whether to download artifacts from a triggering build. |
-| `tags`<br/>Build Tags | A coma-delimited list of tags. Only builds with these tags will be returned. |
-| `artifactName`<br/>Artifact Name | The name of the artifact to download. If left empty, all artifacts associated to the pipeline run will be downloaded. |
-| `itemPattern`<br/>Matching Patterns | One or more file matching patterns (new line delimited) that limit which files get downloaded. [More Information on file matching patterns](../file-matching-patterns.md) |
-| `targetPath`<br/>Destination Directory | Directory to download the artifact files. Can be relative to the pipeline workspace directory or absolute. If multi-download option is applied (by leaving an empty artifact name), a sub-directory will be created for each. See [Artifacts in Azure Pipelines](../../artifacts/pipeline-artifacts.md). |
-| `project`<br/>Project | The project GUID from which to download the pipeline artifacts. |
-| `definition`<br/>Build Pipeline | The definition ID of the build pipeline. |
-| `buildVersionToDownload`<br/>Build version to download | Specifies which build version to download. Options: `latest`, `latestFromBranch`, `specific` |
-| `branchName`<br/>Branch Name | Specify to filter on branch/ref name, for example: `refs/heads/develop`. |
-| `pipelineId`<br/>Build | The build from which to download the artifacts. For example: `1764` |
+| Argument | Aliases | Description |
+| -------- | ------- | ----------- |
+| `buildType`<br/>Download artifacts produced by | `source` | Download artifacts produced by the current pipeline run, or from a specific pipeline run.<br/>Options: `current`, `specific` |
+| `specificBuildWithTriggering`<br/>When appropriate, download artifacts from the triggering build | | A boolean specifying whether to download artifacts from a triggering build. |
+| `tags`<br/>Build Tags | | A coma-delimited list of tags. Only builds with these tags will be returned. |
+| `artifactName`<br/>Artifact Name | `artifact` | The name of the artifact to download. If left empty, all artifacts associated to the pipeline run will be downloaded. |
+| `itemPattern`<br/>Matching Patterns | `patterns` | One or more file matching patterns (new line delimited) that limit which files get downloaded. [More Information on file matching patterns](../file-matching-patterns.md) |
+| `targetPath`<br/>Destination Directory | `path`, `downloadPath` | Directory to download the artifact files. Can be relative to the pipeline workspace directory or absolute. If multi-download option is applied (by leaving an empty artifact name), a sub-directory will be created for each. See [Artifacts in Azure Pipelines](../../artifacts/pipeline-artifacts.md). |
+| `project`<br/>Project | | The project GUID from which to download the pipeline artifacts. |
+| `definition`<br/>Build Pipeline | `pipeline` | The definition ID of the build pipeline. |
+| `buildVersionToDownload`<br/>Build version to download | `runVersion` | Specifies which build version to download. Options: `latest`, `latestFromBranch`, `specific` |
+| `branchName`<br/>Branch Name | `runBranch` | Specify to filter on branch/ref name, for example: `refs/heads/develop`. |
+| `pipelineId`<br/>Build | `runId`, `buildId` | The build from which to download the artifacts. For example: `1764` |
 | [!INCLUDE [control-options-arguments-md](../_shared/control-options-arguments-md.md)] | |
 
 ## Examples


### PR DESCRIPTION
See #5505.  The underlying issue is that there are multiple names for several of the parameters, and these different names are confusing (e.g. there's a pipeline parameter that takes an id, and also pipelineId parameter, but these do different things!).  In addition to the work that's already been done to clarify the documentation, this PR adds the names of aliases for all of the arguments.  This will especially help those who already have code written understand what the available parameters are.