### PR TITLE
Please add 2 URLs for authentication

### DIFF
--- a/docs/organizations/security/allow-list-ip-url.md
+++ b/docs/organizations/security/allow-list-ip-url.md
@@ -108,6 +108,8 @@ If your organization use security measures, like a firewall or a proxy server, a
 - https://go.microsoft.com
 - https://graph.windows.net
 - https://app.vssps.visualstudio.com
+- https://aadcdn.msauth.net
+- https://aadcdn.msftauth.net
 
 ### A more general list of URLs for signing into Azure DevOps and Azure
 


### PR DESCRIPTION
These URLs are missing in the list for sign-in. 

https://aadcdn.msftauth.net
https://aadcdn.msauth.net

If these URLs are blocked by Proxy/Firewall/NSG, sign-in to Azure DevOps services fails.

According to AAD support team, the number 56 and 57 described below are generally used for AAD authentication.
https://docs.microsoft.com/en-us/office365/enterprise/urls-and-ip-address-ranges?redirectSourcePath=%252fen-us%252farticle%252fOffice-365-URLs-and-IP-address-ranges-8548a211-3fe7-47cb-abb1-355ea5aa88a2#microsoft-365-common-and-office-online

However, I confirmed that only 2 URLs could be used for authentication after connecting to login.microsoftonline.com when I sign-in to my organization. So, I think we need at least these URLs to complete sign-in.