### PR TITLE
Add description about Microsoft-hosted agent.

### DIFF
--- a/docs/organizations/security/allow-list-ip-url.md
+++ b/docs/organizations/security/allow-list-ip-url.md
@@ -79,6 +79,10 @@ If your organization uses ExpressRoute, ensure the following addresses are allow
 
 For more information about Azure DevOps and ExpressRoute, see [ExpressRoute for Azure DevOps](https://devblogs.microsoft.com/devops/expressroute-for-azure-devops/). 
 
+## Using Microsoft-hosted Agents
+
+If you use Microsoft-hosted agent to run your jobs and you need the information about what IP addresses are used, see [Microsoft-hosted agents Agent IP ranges](../../pipelines/agents/hosted.md#agent-ip-ranges).
+
 ## Connecting Private Build Agents
 
 If you're running a firewall and your code is in Azure Repos, see [Self-hosted Windows agents FAQ](../../pipelines/agents/v2-windows.md#im-running-a-firewall-and-my-code-is-in-azure-repos-what-urls-does-the-agent-need-to-communicate-with). This article has information about which URLs and IP addresses your private agent needs to communicate with. 


### PR DESCRIPTION
We can use Microsoft-hosted agent to deploy applications, but sometimes there are firewall/proxy/restricted IP configuration between DevOps and destinations. In this case, users must know VMs for Microsoft-hosted agent use any of Azure datacenters IP range. This has impact for users and they may need to consider using Self-hosted agent. So this page should have the link to Microsoft-hosted agent page so that users can find the information easily.