### PR TITLE
Harmonized casing in Rev-parameter description

### DIFF
--- a/docs/pipelines/process/run-number.md
+++ b/docs/pipelines/process/run-number.md
@@ -84,7 +84,7 @@ The following table shows how each token is resolved based on the previous examp
 | `$(Hours)` | 21 |
 | `$(Minutes)` | 7 |
 | `$(Month)` | 8 |
-| `$(Rev:r)` | 2 (The third run on this day will be 3, and so on.)<br /><br />Use **$(Rev:r)** to ensure that every completed build has a unique name. When a build is completed, if nothing else in the build number has changed, the Rev integer value is incremented by one.<br /><br />If you want to show prefix zeros in the number, you can add additional **'r'** characters. For example, specify **$(rev:rr)** if you want the Rev number to begin with 01, 02, and so on. |
+| `$(Rev:r)` | 2 (The third run on this day will be 3, and so on.)<br /><br />Use **$(Rev:r)** to ensure that every completed build has a unique name. When a build is completed, if nothing else in the build number has changed, the Rev integer value is incremented by one.<br /><br />If you want to show prefix zeros in the number, you can add additional **'r'** characters. For example, specify **$(Rev:rr)** if you want the Rev number to begin with 01, 02, and so on. |
 | `$(Date:yyyyMMdd)` | 20090824<br /><br />You can specify other date formats such as **$(Date:MMddyy)** |
 | `$(Seconds)` | 3 |
 | `$(SourceBranchName)` | master |


### PR DESCRIPTION
Use uniform casing for the `Rev` parameter in the example. It was lower case, whereas throughout the rest of the document it is consistently referred to as starting with an uppercase `R`. This may lead to the false impression that the casing influences the working of the replacement.