### PR TITLE
Android testing: remove unnecessary "echo"

### DIFF
--- a/docs/pipelines/ecosystems/android.md
+++ b/docs/pipelines/ecosystems/android.md
@@ -126,7 +126,7 @@ Don't forget to arrange the emulator parameters to fit your testing environment.
 # Create emulator
 echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n xamarin_android_emulator -k 'system-images;android-27;google_apis;x86' --force
 
-echo $ANDROID_HOME/emulator/emulator -list-avds
+$ANDROID_HOME/emulator/emulator -list-avds
 
 echo "Starting emulator"
 


### PR DESCRIPTION
We want to run the command, not print it.