### PR TITLE
Replace DotNetCoreInstaller with UseDotNet

### DIFF
--- a/docs/pipelines/ecosystems/dotnet-core.md
+++ b/docs/pipelines/ecosystems/dotnet-core.md
@@ -136,9 +136,10 @@ If you need a version of the .NET Core SDK that isn't already installed on the M
 ```yaml
 # do this before all your .NET Core tasks
 steps:
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK'
   inputs:
-    version: '2.1.300' # replace this value with the version that you need for your project
+    version: 3.0.100
 # ...
 ```
 


### PR DESCRIPTION
Per the warning message I just got, it looks like `DotNetCoreInstaller` is deprecated in favor of `UseDotNet`

Based on the link in the error message
```
##[warning]Kindly upgrade to new major version of this task 'Use .NET Core (2.*)' for installing newer versions of .NET Core. '0.*' task version might not be able to download newer .NET core versions. To know more about 'Use Dot Net (2.*)', refer https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops. 3.0.100
```

I updated the code snippet to use the new task.