### PR TITLE
Update triggers.md path filter wildcard limitation section

### DIFF
--- a/docs/pipelines/build/triggers.md
+++ b/docs/pipelines/build/triggers.md
@@ -851,7 +851,9 @@ Wildcards patterns allow `*` to match zero or more characters and `?` to match a
 For branches and tags, a wildcard may appear anywhere in the pattern.
 
 For paths, you may include `*` as the final character, but it doesn't do anything differently from specifying the directory name by itself.
-You may not include `*` in the middle of a path filter, and you may not use `?`.
+
+> [!IMPORTANT]
+> You may **not** include `*` in the middle of a path filter, and you may not use `?`.
 
 ```yaml
 trigger:


### PR DESCRIPTION
Trying to make the path filter wildcard limitation a bit more obvious.