### PR TITLE
Uncomment incorrectly commented-out line in code sample to launch emulator

### DIFF
--- a/docs/pipelines/ecosystems/android.md
+++ b/docs/pipelines/ecosystems/android.md
@@ -121,7 +121,7 @@ Don't forget to arrange the emulator parameters to fit your testing environment.
 #!/usr/bin/env bash
 
 # Install AVD files
-# echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-27;google_apis;x86'
+echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-27;google_apis;x86'
 
 # Create emulator
 echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n xamarin_android_emulator -k 'system-images;android-27;google_apis;x86' --force

--- a/docs/pipelines/ecosystems/android.md
+++ b/docs/pipelines/ecosystems/android.md
@@ -9,7 +9,7 @@ ms.manager: jillfra
 ms.author: dastahel
 ms.reviewer: dastahel
 ms.custom: seodec18
-ms.date: 08/31/2018
+ms.date: 10/07/2019
 monikerRange: 'azure-devops'
 ---
 


### PR DESCRIPTION
In the code snippet describing the code required to launch an Android Emulator on the Azure Pipeline agent, the line which invokes `sdkmanager` to download the emulator image is commented out. However, this emulator image is not preloaded on the agent VMs, so this line must be uncommented for these instructions to work. In the solution to [this Developer Community post](https://developercommunity.visualstudio.com/content/problem/340547/azure-devops-unable-to-run-the-android-emulator-on.html), similar code is provided by a Microsoft rep with the line in question uncommented.