### PR TITLE
Fix incorrect/inconsistent names of Pipeline Artifacts arguments

### DIFF
--- a/docs/pipelines/tasks/_shared/yaml/PublishPipelineArtifactV1.md
+++ b/docs/pipelines/tasks/_shared/yaml/PublishPipelineArtifactV1.md
@@ -4,5 +4,5 @@
 - task: PublishPipelineArtifact@1
   inputs:
     #targetPath: '$(Pipeline.Workspace)' 
-    #artifact: # Optional
+    #artifactName: # 'drop'
 ```

--- a/docs/pipelines/tasks/utility/publish-pipeline-artifact.md
+++ b/docs/pipelines/tasks/utility/publish-pipeline-artifact.md
@@ -9,7 +9,7 @@ ms.manager: jillfra
 ms.custom: seodec18
 ms.author: wismyth
 author: willsmythe
-ms.date: 12/07/2018
+ms.date: 10/07/2019
 monikerRange: 'azure-devops'
 ---
 
@@ -35,7 +35,7 @@ None
 
 | Argument | Description |
 | -------- | ----------- |
-| path | Path to the folder or file you want to publish. The path must be a fully-qualified path or a valid path relative to the root directory of your repository. See [Artifacts in Azure Pipelines](../../artifacts/pipeline-artifacts.md). |
+| targetPath | Path to the folder or file you want to publish. The path must be a fully-qualified path or a valid path relative to the root directory of your repository. See [Artifacts in Azure Pipelines](../../artifacts/pipeline-artifacts.md). |
 | artifactName | Specify the name of the artifact that you want to create. It can be whatever you want. For example: `drop` |
 | [!INCLUDE [control-options-arguments-md](../_shared/control-options-arguments-md.md)] | |
 


### PR DESCRIPTION
On the [Pipeline Artifacts] documentation, the names of the expected arguments are inconsistent between the YAML snippet and the table below. As it happens, neither one is entirely correct -- one name from each is correct, and the `artifactName` parameter is incorrectly listed as optional. This PR corrects these issues, and should resolve both issues #5275 and #5858.