### PR TITLE
Added old ignore flag for reference

### DIFF
--- a/docs/repos/git/ignore-files.md
+++ b/docs/repos/git/ignore-files.md
@@ -134,7 +134,8 @@ Resume tracking files with:
 </pre>
 
 Alternatively, you can use the following flags, however, these are primarily for marking files that should not be changed by developers:
-Disable changetracking
+
+Disable change tracking
 <pre style="color:white;background-color:black;font-family:Consolas,Courier,monospace;padding:10px">
 &gt; git update-index --assume-unchanged <font color="#b5bd68">&lt;file&gt;</font>
 </pre>

--- a/docs/repos/git/ignore-files.md
+++ b/docs/repos/git/ignore-files.md
@@ -133,6 +133,17 @@ Resume tracking files with:
 &gt; git update-index --no-skip-worktree <font color="#b5bd68">&lt;file&gt;</font>
 </pre>
 
+Alternatively, you can use the following flags, however, these are primarily for marking files that should not be changed by developers:
+Disable changetracking
+<pre style="color:white;background-color:black;font-family:Consolas,Courier,monospace;padding:10px">
+&gt; git update-index --assume-unchanged <font color="#b5bd68">&lt;file&gt;</font>
+</pre>
+
+Resume change tracking
+<pre style="color:white;background-color:black;font-family:Consolas,Courier,monospace;padding:10px">
+&gt; git update-index --no-assume-unchanged <font color="#b5bd68">&lt;file&gt;</font>
+</pre>
+
 #### Permanently ignore changes to a file
 
 If a file is already tracked by Git, adding that file to your .gitignore is not enough to ignore changes to the file. You also need to 


### PR DESCRIPTION
--assume-unchanged (and it's counterpart --no-assume-unchanged) were removed from documentation after developers have used this file for reference. By removing the resume tracking flag it makes it more difficult for developers who used the wrong one to enable change tracking again. In light of that both flags should be present with language specifying which flag is preferred.