### PR TITLE
Small typo with YAML schema for pipeline resource in releaste notes

### DIFF
--- a/release-notes/2019/_shared/pipelines/sprint-159-update.md
+++ b/release-notes/2019/_shared/pipelines/sprint-159-update.md
@@ -33,8 +33,8 @@ Here is the detailed YAML schema for pipelines resource.
 resources: 
   pipelines:
   - pipeline: MyAppCI  # identifier for the pipeline resource
-        project:  DevOpsProject # project for the build pipeline; optional input for current project
-        source: MyCIPipeline  # source pipeline definition name
+    project:  DevOpsProject # project for the build pipeline; optional input for current project
+    source: MyCIPipeline  # source pipeline definition name
     branch: releases/M159  # branch to pick the artifact, optional; defaults to all branches
     version: 20190718.2 # pipeline run number to pick artifact; optional; defaults to last successfully completed run
     trigger:     # Optional; Triggers are not enabled by default.


### PR DESCRIPTION
There is a small inundation typo for pipeline resource triggers. There are additional spaces which I have fixed. 