### PR TITLE
Docker@2 task buildAndPush command ignores arguments property

### DIFF
--- a/docs/pipelines/tasks/build/docker.md
+++ b/docs/pipelines/tasks/build/docker.md
@@ -9,6 +9,7 @@ ms.manager: shasb
 ms.author: shasb
 author: shashankbarsin
 ms.date: 02/12/2019
+ms.custom: fasttrack-edit
 monikerRange: '>= tfs-2018'
 ---
 
@@ -68,7 +69,7 @@ Following are the key benefits of using Docker task as compared to directly usin
   </tr>
   <tr>
     <td><code>arguments</code><br/>Arguments</td>
-    <td>(Optional) Additional arguments to be passed onto the docker client</td>
+    <td>(Optional) Additional arguments to be passed onto the docker client<br />Be aware that if you use value *buildandPush* for the command parameter, then the arguments property will be ignored.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Adjusting the documentation to show that if you use the Docker V2 task using the *buildAndPush* command, then any arguments passed in will be ignored.

This can be seen in the code on the task available at https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/DockerV2/dockerbuild.ts#L23 

This may save people some time, as i had tried condensing my Docker@1 task from Build / push (separate tasks) to Docker@2 buildAndPush and encountered this.