### PR TITLE
adding bash guidance for env variable export

### DIFF
--- a/docs/cli/service_endpoint.md
+++ b/docs/cli/service_endpoint.md
@@ -39,6 +39,10 @@ az devops service-endpoint azurerm create
 
 In interactive mode this command will ask for service principal password/secret using a prompt message, for automation purpose set service principal password/secret in `AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY` environment variable.
 
+```bash
+export AZURE_DEVOPS_EXT_AZURE_RM_SERVICE_PRINCIPAL_KEY=<your_secret_here>
+```
+
 ### Using client certificate
 
 If AAD application uses [certificate for authentification](/azure/active-directory/develop/active-directory-certificate-credentials) then create .pem for the certificate and pass path to .pem file in `--azure-rm-service-principal-certificate-path` argument.


### PR DESCRIPTION
if using a shell variable, az will not recognized it.