### PR TITLE
Added missing dependency on sync-request

### DIFF
--- a/docs/extend/develop/add-build-task.md
+++ b/docs/extend/develop/add-build-task.md
@@ -260,6 +260,7 @@ We use [Mocha](https://mochajs.org/) as the test driver in this walk through.
 
 ```
 npm install mocha --save-dev -g
+npm install sync-request --save-dev
 npm install @types/mocha --save-dev
 ```
 


### PR DESCRIPTION
Without the `sync-request` module mocha would fail with the following error message due to a missing dependency

```
internal/modules/cjs/loader.js:638
throw err;
^
Error: Cannot find module 'sync-request'
at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
at Function.Module._load (internal/modules/cjs/loader.js:562:25)
at Module.require (internal/modules/cjs/loader.js:692:17)
at require (internal/modules/cjs/helpers.js:25:18)
```

In order to be able to run the tests successfully you need to ensure that sync-request is installed, so I've added it as a requirement when installing Mocha

This results in being able to follow the guide step-by-step and apply the commands locally without error

Fixes https://github.com/MicrosoftDocs/vsts-docs/issues/6141 
Fixes https://github.com/MicrosoftDocs/vsts-docs/issues/6213
Fixes [AB#1638569](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1638569)
