### PR TITLE
Better definition for locking strategy

### DIFF
--- a/docs/repos/git/lock-branches.md
+++ b/docs/repos/git/lock-branches.md
@@ -24,7 +24,7 @@ Locking also blocks any new commits from being added to the branch by others.
 ## Locking limitations
 
 Locking is ideal for preventing new changes that might conflict with an important merge or to place a branch into a read-only state. 
-Use [branch policies](branch-policies.md) and [pull requests](pull-requests.md) instead of locking if you just want to ensure that changes in a branch are reviewed before they are merged.
+Use [branch policies](branch-policies.md) and [pull requests](pull-requests.md) with locking if you want to ensure that changes in a branch are reviewed before they are merged and prevent changes in the locked branch.
 
 Locking does not prevent cloning of a repo or fetching updates made in the branch into your local repo.
 Share with your team the reason for the locking of the branch and make sure your team knows what to do to work with the branch after it is unlocked. 


### PR DESCRIPTION
As it said before, the lock prevents changes directly to the locked branch, and a pull request can change a branch locked, so the change made here is just to put things more clear.