### PR TITLE
.exe removal in examples + anonymous note

### DIFF
--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -18,7 +18,7 @@ monikerRange: 'azure-devops'
 Azure Artifacts provides an easy way to share your PowerShell scripts and books across your entire team or company. By storing your PowerShell scripts in a private NuGet repository within Azure Artifacts, you can give members of your team the ability to download or update them quickly using the command line.
 
 > [!NOTE]
-> This guide assumes you've already set up Azure Artifacts. You can check out how to license the extension in the [License Azure Artifacts guide](../start-using-azure-artifacts.md).
+> This guide assumes you've already set up Azure Artifacts. You can check out how to license the extension in the [License Azure Artifacts guide](../start-using-azure-artifacts.md). Regardless of the license, make note of that Azure DevOps Services doesn't not support Anonymous Authentication over HTTP.
 
 In this tutorial, you'll learn how to use Azure Artifacts as a private PowerShell repository that your team can download and upload PowerShell modules to. You'll complete the following steps:
 
@@ -27,9 +27,6 @@ In this tutorial, you'll learn how to use Azure Artifacts as a private PowerShel
 > * Create a feed within Azure Artifacts that will be used to store your PowerShell modules
 > * Create, package, and send a PowerShell module to your Azure Artifacts Feed
 > * Connect to the feed from PowerShell to see and download your modules  
-
-> [!NOTE]
-> Azure DevOps Services doesn't allow for anonymous authentication.
 
 ## Prerequisites
 

--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -28,6 +28,9 @@ In this tutorial, you'll learn how to use Azure Artifacts as a private PowerShel
 > * Create, package, and send a PowerShell module to your Azure Artifacts Feed
 > * Connect to the feed from PowerShell to see and download your modules  
 
+> [!NOTE]
+> Azure DevOps Services doesn't allow for anonymous authentication.
+
 ## Prerequisites
 
 1. [The NuGet CLI](https://docs.microsoft.com/nuget/tools/nuget-exe-cli-reference)
@@ -200,17 +203,17 @@ We now have the module and the module manifest. We are ready to package it and s
 
     Add the Azure DevOps Services repo as a source for NuGet:
     ```powershell
-    nuget.exe sources Add -Name "PowershellModules" -Source "https://pkgs.dev.azure.com/<org_name>/_packaging/<feed_name>/nuget/v3/index.json"
+    nuget sources Add -Name "PowershellModules" -Source "https://pkgs.dev.azure.com/<org_name>/_packaging/<feed_name>/nuget/v3/index.json"
     ```
     
     If you're still using the older ```visualstudio.com``` URLs, use this command instead:
     ```powershell
-    nuget.exe sources Add -Name "PowershellModules" -Source "https://<org_name>.pkgs.visualstudio.com/_packaging/<feed_name>/nuget/v3/index.json"
+    nuget sources Add -Name "PowershellModules" -Source "https://<org_name>.pkgs.visualstudio.com/_packaging/<feed_name>/nuget/v3/index.json"
     ```
 
     Push the file to the NuGet feed in Azure Artifacts. You will have to change the name of the `.nupkg` file:
     ```powershell
-    nuget.exe push -Source "PowershellModules" -ApiKey AzureDevOpsServices Get-Hello.nupkg
+    nuget push -Source "PowershellModules" -ApiKey AzureDevOpsServices Get-Hello.nupkg
     ```
 
 After the `nuget.exe push` command, PowerShell will ask you for your credentials. The first is a username which is not tied to anything. The second is the password. You can copy and paste your Azure DevOps Services PAT from before. Upon entering your access token, our module is now able to be installed from our feed in Azure Artifacts.

--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -213,7 +213,7 @@ We now have the module and the module manifest. We are ready to package it and s
     nuget push -Source "PowershellModules" -ApiKey AzureDevOpsServices Get-Hello.nupkg
     ```
 
-After the `nuget.exe push` command, PowerShell will ask you for your credentials. The first is a username which is not tied to anything. The second is the password. You can copy and paste your Azure DevOps Services PAT from before. Upon entering your access token, our module is now able to be installed from our feed in Azure Artifacts.
+After the `nuget push` command, PowerShell will ask you for your credentials. The first is a username which is not tied to anything. The second is the password. You can copy and paste your Azure DevOps Services PAT from before. Upon entering your access token, our module is now able to be installed from our feed in Azure Artifacts.
 
 ## Connecting to the feed as a PowerShell repo
 

--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -18,7 +18,7 @@ monikerRange: 'azure-devops'
 Azure Artifacts provides an easy way to share your PowerShell scripts and books across your entire team or company. By storing your PowerShell scripts in a private NuGet repository within Azure Artifacts, you can give members of your team the ability to download or update them quickly using the command line.
 
 > [!NOTE]
-> This guide assumes you've already set up Azure Artifacts. You can check out how to license the extension in the [License Azure Artifacts guide](../start-using-azure-artifacts.md). Regardless of the license, make note of that Azure DevOps Services doesn't not support Anonymous Authentication over HTTP.
+> This guide assumes you've already set up Azure Artifacts. You can check out how to license the extension in the [License Azure Artifacts guide](../start-using-azure-artifacts.md).
 
 In this tutorial, you'll learn how to use Azure Artifacts as a private PowerShell repository that your team can download and upload PowerShell modules to. You'll complete the following steps:
 


### PR DESCRIPTION
#4318 can be closed.

Also added information about the fact that Azure DevOps doesn't support anonymous authentication since PAT is the ONLY method for accessing when using as PS repo.