### PR TITLE
Added NOTE about enabling SQL Server Auth mode

### DIFF
--- a/docs/migrate/migration-import.md
+++ b/docs/migrate/migration-import.md
@@ -548,6 +548,8 @@ CREATE LOGIN fabrikam WITH PASSWORD = 'fabrikamimport1!'
 CREATE USER fabrikam FOR LOGIN fabrikam WITH DEFAULT_SCHEMA=[dbo]
 EXEC sp_addrolemember @rolename='TFSEXECROLE', @membername='fabrikam'
 ```
+> [!NOTE]   
+> Be sure to enable [SQL Server and Windows Authentication mode](https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/change-server-authentication-mode?view=sql-server-ver15#SSMSProcedure) in SQL Server Management Studio on the VM.  If you do not enable SQL Server and Windows Authentication mode, the import will fail.    
 
 #### Configure the Import Specification File to Target the VM
 The import specification file will need to be updated to include information on how to connect to the SQL instance. Open your import specification file and make the following updates:


### PR DESCRIPTION
I've made this mistake a couple times now (one too many).  Without enabling SQL logins on the server, we receive the following error:
![image](https://user-images.githubusercontent.com/32681667/68497561-d2fa8b00-0222-11ea-9007-af7c3d794f09.png)
After checking the inbound port rules, and finding that this port is open to inbound traffic I was stumped.  I think that this note will be useful for people that are less familiar with SQL server such as myself.