### PR TITLE
Corrections for work item operations permissioning

### DIFF
--- a/docs/organizations/security/about-permissions.md
+++ b/docs/organizations/security/about-permissions.md
@@ -34,7 +34,8 @@ Here's what you need to know about permission settings:
 
 - For most groups and almost all permissions, **Deny** overrides **Allow**. If a user belongs to two groups, and one of them has a specific permission set to **Deny**, that user is not able to perform tasks that require that permission even if they belong to a group that has that permission set to **Allow**.
 
-    For members of the **Project Collection Administrators** or **Team Foundation Administrators** groups, Deny doesn't trump Allow. Permissions assigned to these groups take precedent over any Deny set within any other group to which that member might belong.
+    For members of the **Project Collection Administrators** or **Team Foundation Administrators** groups, Deny doesn't trump Allow. Permissions assigned to these groups take precedent over any Deny set within any other group to which that member might belong. 
+	> **Project Collection Administrators** or **Team Foundation Administrators** permissions will not take precedence for work item operations, such as deletion. **Deny** will override **Allow**  for these permissions.
 
 - Changing a permission for a group changes that permission for all users who are members of that group. In other words, depending on the size of the group, you might affect the ability of hundreds of users to do their jobs by changing just one permission. So make sure you understand the impact before you make a change.
 
@@ -53,7 +54,7 @@ and it is denied, either directly or through group membership,
 the permission is denied.
 
 	> Members of **Project Collection Administrators** or **Team Foundation Administrators**
-	> retain any allowed permissions, even if they belong to other groups that deny those permissions.
+	> retain most allowed permissions, even if they belong to other groups that deny those permissions. Work item operation permissions are the exception to this rule.
 
 - Object-level permissions that are assigned for nodes of a hierarchy -
 areas, iterations, version control folders, work item query folders -


### PR DESCRIPTION
PCA or TFA permissions will not take precedence over others for work item operations, such as deletion. Any Deny inherited from group membership will trump these Admin rights.

Edited all references.