### PR TITLE
Update yaml-schema.md - fixing format issues with download task

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1691,11 +1691,14 @@ steps:
   patterns: string # patterns representing files to include; optional
 ```
 ### Artifact download location
-Artifacts from current pipeline are downloaded to `$(Pipeline.Workspace)/`. 
+
+Artifacts from the current pipeline are downloaded to `$(Pipeline.Workspace)/`.
+
 Artifacts from the associated `pipeline` resource are downloaded to `$(Pipeline.Workspace)/<pipeline resource identifier>/`.
 
 ### Automatic download in deployment jobs
-All the available artifacts from current pipeline as well as from associated pipeline resources are automatically downloaded in deployment jobs and made available for your deployment. However you can choose to not download by specifiying `download: none` 
+
+All available artifacts from the current pipeline and from the associated pipeline resources are automatically downloaded in deployment jobs and made available for your deployment. However, you can choose to not download by specifiying `download: none`.
 
 # [Example](#tab/example)
 

--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -1690,6 +1690,12 @@ steps:
   artifact: string # artifact name; optional; downloads all the avaialable artifacts if not specified
   patterns: string # patterns representing files to include; optional
 ```
+### Artifact download location
+Artifacts from current pipeline are downloaded to `$(Pipeline.Workspace)/`. 
+Artifacts from the associated `pipeline` resource are downloaded to `$(Pipeline.Workspace)/<pipeline resource identifier>/`.
+
+### Automatic download in deployment jobs
+All the available artifacts from current pipeline as well as from associated pipeline resources are automatically downloaded in deployment jobs and made available for your deployment. However you can choose to not download by specifiying `download: none` 
 
 # [Example](#tab/example)
 
@@ -1701,13 +1707,6 @@ steps:
 - download: MyAppA   # downloads artifacts available as part of the pipeline resource
 
 ```
-### Artifact download location
-Artifacts from current pipeline are downloaded to `$(Pipeline.Workspace)/`. 
-Artifacts from the associated `pipeline` resource are downloaded to `$(Pipeline.Workspace)/<pipeline resource identifier>/`.
-
-### Automatic download in deployment jobs
-All the available artifacts from current pipeline as well as from associated pipeline resources are automatically downloaded in deployment jobs and made available for your deployment. However you can choose to not download by specifiying `download: none` 
-
 ---
 
 Learn more about [downloading artifacts](./artifacts/pipeline-artifacts.md#downloading-artifacts).


### PR DESCRIPTION
Mistakenly, the info about the download artifacts is being shown under example section for `download` task. It should be shown under schema which is the default view. Fixed it accordingly.