### PR TITLE
Updating to indicate that a banner of a type remains till expiry

### DIFF
--- a/docs/organizations/settings/manage-banners.md
+++ b/docs/organizations/settings/manage-banners.md
@@ -17,7 +17,7 @@ ms.date: 08/15/2019
 
 [!INCLUDE [temp](../../_shared/version-vsts-only.md)]  
 
-A quick and effective way to communicate with your organization is through information banners. You can specify one of three types of banners: error, information, and warning. Only one banner, the last one added or updated, is displayed at a time. Banners remain in effect until their expiration date. 
+A quick and effective way to communicate with your organization is through information banners. You can specify one of three types of banners: error, information, and warning. Only one banner of a particular type is displayed at a time. Banners remain in effect until their expiration date. 
 
 The following image shows how an information message is displayed. Users can cancel the message by clicking the ![ ](../../_img/icons/close-filter.png) close icon. 
 


### PR DESCRIPTION
Updating doc to reflect functionality more accurately.

Say the user created banner 1 of type info with expiry date as "11-11-2019".
Say the user created banner 2 also of type info with expiry date as "11-11-2019".

As per the current documentation, I get the sense that banner 2 will be displayed due to the section - _**the last one** added or updated_*.

However, as per the functionality which I tested again to verify, banner 1 is rendered. This is because only one banner of a particular type is allowed and that remains till expiry is achieved or explicitly removed.

Including @atbagga , @ishitam8, @willsmythe and @wnjenkin