### PR TITLE
Agent.TempDirectory Clean Verbiage

### DIFF
--- a/docs/pipelines/build/_shared/variables-hosted.md
+++ b/docs/pipelines/build/_shared/variables-hosted.md
@@ -88,7 +88,7 @@ The operating system processor architecture of the agent host. Valid values are:
 <tr>
 <td>Agent.TempDirectory</td>
 <td>
-A temporary folder that is cleaned after each pipeline run. This directory is used by tasks such as <a href="/azure/devops/pipelines/tasks/build/dotnet-core-cli">.NET Core CLI task</a> to hold temporary items like test results before they are published.
+A temporary folder that is cleaned after each pipeline job run. This directory is used by tasks such as <a href="/azure/devops/pipelines/tasks/build/dotnet-core-cli">.NET Core CLI task</a> to hold temporary items like test results before they are published.
 </td>
 </tr>
 


### PR DESCRIPTION
Agent.TempDirectory is cleaned after each **job** in a pipeline. I had some files being put in this directory in the first job in a pipeline. After that job execution completed, the files were removed and unable to be used in subsequent jobs.