### PR TITLE
Clarify that variable groups can be used for passing secrets into YAML pipelines

### DIFF
--- a/docs/pipelines/library/variable-groups.md
+++ b/docs/pipelines/library/variable-groups.md
@@ -18,7 +18,8 @@ monikerRange: '>= tfs-2017'
 [!INCLUDE [temp](../_shared/concept-rename-note.md)]
 
 Use a variable group to store values that you want to control and make available across
-multiple pipelines. Variable groups are defined and managed in the **Library** page under
+multiple pipelines. You can also use variable groups to store secrets and other values
+that might need to be [passed into a YAML pipeline](variable-groups.md?tabs=yaml&view=azure-devops#use-a-variable-group). Variable groups are defined and managed in the **Library** page under
 **Pipelines**.
 
 ::: moniker range="< tfs-2018"


### PR DESCRIPTION
This PR clarifies a point of confusion that I have seen with several customers, which is how to pass secrets into multi-stage YAML pipelines that have release stages.

A common use case is to use multi-stage YAML pipelines to deploy application to multiple environments, and frequently applications need to have environment-specific secrets flowed into their configuration systems through a pipeline (e.g. an API key for an external API). Currently, it appears that variable groups are the best and recommended approach to achieve this, so clarifying this within the documentation would be advantageous.