### PR TITLE
Small typo error in the YAML

### DIFF
--- a/release-notes/2019/_shared/pipelines/sprint-160-update.md
+++ b/release-notes/2019/_shared/pipelines/sprint-160-update.md
@@ -86,7 +86,7 @@ resources:
   - container: MyACR  #container resource alias
     type: ACR
     azureSubscription: RMPM  #ARM service connection
-    resourcegroup: contosoRG
+    resourceGroup: contosoRG
     registry: contosodemo
     repository: alphaworkz
     trigger: 


### PR DESCRIPTION
There was a small typo error in the yaml schema for 'resourceGroup' keyword.