### PR TITLE
Fixed inconsistency in markdown-guidance.md

### DIFF
--- a/docs/project/wiki/markdown-guidance.md
+++ b/docs/project/wiki/markdown-guidance.md
@@ -163,7 +163,7 @@ Quote blocks of lines of text by using the same level of `>` across many lines.
 
 <pre>
 > Single line quote
->> Nested
+>> Nested quote
 >> multiple line
 >> quote
 </pre>


### PR DESCRIPTION
There was an inconsistency between the example code and the result in the Blockquotes section.