### PR TITLE
Updated GitHub repo links to use the new URLs

### DIFF
--- a/docs/integrate/get-started/client-libraries/samples.md
+++ b/docs/integrate/get-started/client-libraries/samples.md
@@ -18,7 +18,7 @@ Samples showing how to extend and integrate with Team Foundation Server and Azur
 
 
 ## Samples in GitHub
-There are many samples with instructions on how to run them on our [.NET Sample GitHub Page](https://github.com/Microsoft/vsts-dotnet-samples). 
+There are many samples with instructions on how to run them on our [.NET Sample GitHub Page](https://github.com/microsoft/azure-devops-dotnet-samples). 
 
 ## Other samples
 REST examples on this page require the following NuGet packages:
@@ -152,7 +152,7 @@ public static void AADRestSample()
 ```
 
 ##### OAuth Authentication for REST services
-Follow this link to learn how to obtain and refresh an OAuth accessToken: https://github.com/Microsoft/vsts-auth-samples
+Follow this link to learn how to obtain and refresh an OAuth accessToken: https://github.com/microsoft/azure-devops-auth-samples
 ```cs
 public static void OAuthSample()
 {


### PR DESCRIPTION
The old links to other Azure DevOps-related repos had "vsts" in the URL.