### PR TITLE
Corrected file name: ResumeIndexing.ps1

### DIFF
--- a/docs/project/search/administration.md
+++ b/docs/project/search/administration.md
@@ -550,7 +550,7 @@ You're prompted to enter:
 
 ### Resume indexing
 
-If indexing was paused, execute the script **StartSearchIndexing.ps1**
+If indexing was paused, execute the script **ResumeIndexing.ps1**
 with administrative privileges, to start indexing again. 
 You're prompted to enter:
 


### PR DESCRIPTION
The file name `StartSearchIndexing.ps1` does not exist, but instead it's: `ResumeIndexing.ps1`