### PR TITLE
Removing the release note for Cross organization wiki search

### DIFF
--- a/release-notes/2019/_shared/wiki/sprint-159-update.md
+++ b/release-notes/2019/_shared/wiki/sprint-159-update.md
@@ -2,13 +2,6 @@
 ms.topic: include
 ---
 
-### Search for wiki pages across organizations
- 
-You can now search for wiki pages across organizations, without navigating to a different organization, using the **Search within** drop-down on wiki search. The **Search within** drop-down provides a list of all organizations you have access to with the number of hits per organization for the search term. You can use this to navigate through search results from different organization quickly and easily. 
-
-> [!div class="mx-imgBorder"]
-> ![Badge](../../_img/159_05.png)
-
 ### Access recently visited wiki pages
 
 We've made it easy for you to find recently visited wiki pages in the project. You can now access recently visited wiki pages by clicking on the search box in Wiki hub.


### PR DESCRIPTION
The feature to search wiki pages across organizations is not production ready yet and will take time to get releases. Hence removing the feature from the release notes. 
We shall communicate when the feature is ready.