### PR TITLE
replacing sample queries URL account path with organization

### DIFF
--- a/docs/report/powerbi/sample-boards-leadcycletime.md
+++ b/docs/report/powerbi/sample-boards-leadcycletime.md
@@ -34,7 +34,7 @@ This article shows you how to display average lead time or cycle time for a give
 
 ```
 let
-   Source = OData.Feed ("https://analytics.dev.azure.com/{account}/{project}/_odata/v3.0-preview/WorkItems?"
+   Source = OData.Feed ("https://analytics.dev.azure.com/{organization}/{project}/_odata/v3.0-preview/WorkItems?"
         &"$filter=WorkItemType eq 'User Story' "
             &"and StateCategory eq 'Completed' "
             &"and CompletedDate ge {startdate} "
@@ -52,7 +52,7 @@ in
 [!INCLUDE [temp](_shared/sample-odata-query.md)]
 
 ```
-https://analytics.dev.azure.com/{account}/{project}/_odata/v3.0-preview/WorkItems?
+https://analytics.dev.azure.com/{organization}/{project}/_odata/v3.0-preview/WorkItems?
         $filter=WorkItemType eq 'User Story'
             and StateCategory eq 'Completed'
             and CompletedDate ge {startdate}
@@ -161,7 +161,7 @@ This query is the same as the one used above, except it filters by Team Name rat
 
 ```
 let
-   Source = OData.Feed ("https://analytics.dev.azure.com/{account}/{project}/_odata/v3.0-preview/WorkItems?"
+   Source = OData.Feed ("https://analytics.dev.azure.com/{organization}/{project}/_odata/v3.0-preview/WorkItems?"
         &"$filter=WorkItemType eq 'User Story' "
             &"and StateCategory eq 'Completed' "
             &"and CompletedDate ge {startdate} "
@@ -179,7 +179,7 @@ in
 [!INCLUDE [temp](_shared/sample-odata-query.md)]
 
 ```
-https://analytics.dev.azure.com/{account}/{project}/_odata/v3.0-preview/WorkItems?
+https://analytics.dev.azure.com/{organization}/{project}/_odata/v3.0-preview/WorkItems?
         $filter=WorkItemType eq 'User Story'
             and StateCategory eq 'Completed'
             and CompletedDate ge {startdate}

--- a/docs/report/powerbi/sample-boards-openbugs.md
+++ b/docs/report/powerbi/sample-boards-openbugs.md
@@ -176,7 +176,7 @@ You can query for open bugs by Area Path and a specific Iteration.
 
 ```
 let
-   Source = OData.Feed ("https://analytics.dev.azure.com/{account}/{project}/_odata/v3.0-preview/WorkItems?"
+   Source = OData.Feed ("https://analytics.dev.azure.com/{organization}/{project}/_odata/v3.0-preview/WorkItems?"
         &"$filter=WorkItemType eq 'User Story' "
             &"and startswith(Area/AreaPath,'{areapath}') "
             &"and startswith(Iteration/IterationPath,'{iterationpath}') "
@@ -192,7 +192,7 @@ in
 [!INCLUDE [temp](_shared/sample-odata-query.md)]
 
 ```
-https://analytics.dev.azure.com/{account}/{project}/_odata/v3.0-preview/WorkItems?
+https://analytics.dev.azure.com/{organization}/{project}/_odata/v3.0-preview/WorkItems?
         $filter=WorkItemType eq 'User Story'
             and startswith(Area/AreaPath,'{areapath}')
             and startswith(Iteration/IterationPath,'{iterationpath}')


### PR DESCRIPTION
some of the Sample Query URL paths contains an old name {account} and should be updated to use {organization} to be consistent with other MS Docs pages