### PR TITLE
provide yaml keywords for the built in conditions

### DIFF
--- a/docs/pipelines/process/_shared/task-run-built-in-conditions.md
+++ b/docs/pipelines/process/_shared/task-run-built-in-conditions.md
@@ -2,10 +2,10 @@
 ms.topic: include
 ---
 
-* Only when all previous dependencies have succeeded
+* Only when all previous dependencies have succeeded; default if unspecified in a yaml definition
 
-* Even if a previous dependency has failed, unless the run was canceled
+* Even if a previous dependency has failed, unless the run was canceled; specify `succeededOrFailed()` in yaml definition
 
-* Even if a previous dependency has failed, even if the run was canceled
+* Even if a previous dependency has failed, even if the run was canceled; specify `always()` in yaml definition
 
-* Only when a previous dependency has failed
+* Only when a previous dependency has failed; specify `failed()` in yaml definition


### PR DESCRIPTION
I derived these yaml keywords (is that what you'd call them?) by using the view yaml UI in a build definition.  If this is accurate, it'd be great if this made it into the Azure Pipelines YAML vs code extension's Intellisense.  I don't know how to do that which is why I didn't, if you do, please reference the PR here so I can learn.