### PR TITLE
Fix isParameterizedJob parameter name

### DIFF
--- a/docs/pipelines/tasks/build/jenkins-queue-job.md
+++ b/docs/pipelines/tasks/build/jenkins-queue-job.md
@@ -83,7 +83,7 @@ None
       </td>
    </tr>
    <tr>
-      <td><code>parameterizedJob</code><br/>Parameterized job</td>
+      <td><code>isParameterizedJob</code><br/>Parameterized job</td>
       <td>
          <p>(Required) Select if the Jenkins job accepts parameters. This job should be selected even if all default parameter values are used and no parameters are specified.</p><br/>Default value: false
       </td>


### PR DESCRIPTION
Documentation for parameter isParameterizedJob do not match the name in the example (and `ParameterizedJob` does not work in a pipeline, we need to use the name `isParameterizedJob`)