### PR TITLE
Not possible to disable Mac Pools in UI

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -64,11 +64,7 @@ jobs:
 
 ### Notes on choosing "Hosted macOS"
 
-
 This option affects where your data is stored. [Learn more](../../organizations/security/data-location.md).
-
-To disable the Microsoft-hosted macOS agent pool for all projects, disable the `Hosted Agent` checkbox under **Admin settings** > **Agent pools** > **Hosted macOS** and **Admin settings** > **Agent pools** > **Hosted macOS High Sierra**.
-To disable the Microsoft-hosted macOS agent pool for a specific project, disable the `Hosted Agent` checkbox under **Project settings** > **Agent pools** > **Hosted macOS** and **Admin settings** > **Agent pools** > **Hosted macOS High Sierra**.
 
 You can manually select from tool versions on macOS images. [See below](#mac-pick-tools).
 


### PR DESCRIPTION
Since the introduction of "Azure Pipelines Pool" with Agent Specifications it is no longer possible to disable Mac usage across projects.