### PR TITLE
Corrected #env. to $env.

### DIFF
--- a/docs/pipelines/process/variables.md
+++ b/docs/pipelines/process/variables.md
@@ -221,7 +221,7 @@ steps:
     script: |
         # Encode the Personal Access Token (PAT)
         # $env:USER is a normal variable in the variable group
-        # #env:MY_MAPPED_TOKEN is a mapped secret variable
+        # $env:MY_MAPPED_TOKEN is a mapped secret variable
         $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $env:USER,$env:MY_MAPPED_TOKEN)))
         
         # Get a list of releases


### PR DESCRIPTION
Corrected #env.MY_MAPPED_TOKEN to $env.MY_MAPPED_TOKEN

Pretty sure this was a typo.