### PR TITLE
customize-pipeline.md - add missing word

### DIFF
--- a/docs/pipelines/customize-pipeline.md
+++ b/docs/pipelines/customize-pipeline.md
@@ -230,7 +230,7 @@ There are pipeline settings that you wouldn't want to manage in your YAML file. 
 Sometimes you'll want to prevent new runs from starting on your pipeline. 
 
 * By default, the processing of new run requests is **Enabled**. This setting allows standard processing of all trigger types, including manual runs.
-* **Paused** pipelines allow run requests to be processed, but those requests queued without actually starting. When new request processing is enabled, run processing resumes starting with the first request in the queue.
+* **Paused** pipelines allow run requests to be processed, but those requests are queued without actually starting. When new request processing is enabled, run processing resumes starting with the first request in the queue.
 * **Disabled** pipelines prevent users from starting new runs. All triggers are also disabled while this setting is applied. 
 
 ### Other settings


### PR DESCRIPTION
Add missing word in this sentence: "Paused pipelines allow run requests to be processed, but those requests *are* queued without actually starting."