### PR TITLE
List of branches to trigger pipelines doesn't work

### DIFF
--- a/docs/pipelines/repos/azure-repos-git.md
+++ b/docs/pipelines/repos/azure-repos-git.md
@@ -118,8 +118,10 @@ You can control which branches get CI triggers with a simple syntax:
 
 ```yaml
 trigger:
-- master
-- releases/*
+  branches:
+    include:
+    - master
+    - releases/*
 ```
 
 You can specify the full name of the branch (for example, `master`) or a wildcard (for example, `releases/*`).


### PR DESCRIPTION
Documentation give the impression that you can use a plain list of branches to define the ones that will trigger the pipeline, but that doesn't works. It needs to use the "long" version, specifying the `branches` and `includes` nodes. This is similar to how it's defined the default value some lines under.