### PR TITLE
Fix incorrect default value

### DIFF
--- a/docs/pipelines/process/resources.md
+++ b/docs/pipelines/process/resources.md
@@ -53,7 +53,7 @@ resources:        # types: pipelines | builds | repositories | containers | pack
     project: string # project for the source; optional for current project
     source: string  # source definition of the pipeline
     version: string  # the pipeline run number to pick the artifact, defaults to Latest pipeline successful across all stages
-    branch: string  # branch to pick the artifact, optional; defaults to master branch
+    branch: string  # branch to pick the artifact, optional; defaults to all branches
     tag: string # picks the artifacts on from the pipeline with given tag, optional; defaults to no tags
     trigger:     # triggers are not enabled by default unless you add trigger section to the resource
       branches:  # branch conditions to filter the events, optional; Defaults to all branches.


### PR DESCRIPTION
If a branch is not specified for a pipeline resource, all branches are included in artifact selection, not just the master branch. This is stated in the YAML schema page (https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#resources) and appears to be true from my own testing.