### PR TITLE
Removed extra space in refname

### DIFF
--- a/docs/organizations/settings/work/import-process/resolve-errors.md
+++ b/docs/organizations/settings/work/import-process/resolve-errors.md
@@ -1087,7 +1087,7 @@ The Scrum process specifies the following `TypeField` elements. If any of these 
 <TypeFields>
     <TypeField refname="System.AreaPath" type="Team" />
     <TypeField refname="Microsoft.VSTS.Scheduling.RemainingWork" type="RemainingWork" format="format h" />
-    <TypeField refname=" Microsoft.VSTS.Common.BacklogPriority" type="Order" />
+    <TypeField refname="Microsoft.VSTS.Common.BacklogPriority" type="Order" />
     <TypeField refname="Microsoft.VSTS.Scheduling.Effort" type="Effort" />
     <TypeField refname="Microsoft.VSTS.Common.Activity" type="Activity" />
     <TypeField refname="Microsoft.VSTS.Feedback.ApplicationStartInformation" type="ApplicationStartInformation" />


### PR DESCRIPTION
Found an error in:
https://docs.microsoft.com/en-us/azure/devops/organizations/settings/work/import-process/resolve-errors?view=azure-devops#tf402574-processconfiguration-doesnt-specify-required-typefield-typefield

There is an extra space in the refname that causes validation errors if you copy and paste into an xml file.