### PR TITLE
Consolidate exceptions to regions

### DIFF
--- a/docs/organizations/security/data-location.md
+++ b/docs/organizations/security/data-location.md
@@ -34,14 +34,11 @@ We default your organization to your closest region. However, you can choose a d
 
 ## Customer data
 
-Azure DevOps maintains all customer data within your selected geography. Customer data includes the following data types:
+Except as noted below, Azure DevOps maintains all customer data within your selected geography. Customer data includes the following data types:
 - source code
 - work items
 - test results
 - geo-redundant mirrors and offsite backups
-
-> [!NOTE]
-> Because there's only one region in Brazil, customer data is replicated to south-central United States for disaster recovery and load balancing purposes. For more information, see the [Azure data center map](https://azuredatacentermap.azurewebsites.net/).
 
 Azure DevOps works with and uses many Microsoft Azure services. For details on customer data retention by location, see the [Azure data center map](https://azuredatacentermap.azurewebsites.net/).
 
@@ -51,20 +48,30 @@ Azure DevOps stores information that's global in nature, such as user identities
 - US-based users: profile data is in US data center 
 - Users from all other countries: profile data is in US data center 
 
-### Mac builds 
-For builds and releases running on Microsoft-provided macOS agents, your data resides in the United States. This data center is owned and managed by a third party with information security certification assurances, such as ISO 27001 and SOC 2 report. 
-
 ## Transferring your data
 
-Microsoft doesn't transfer customer data outside of your selected region. There can be an exception when Microsoft needs to do any of the following actions:
-- provide customer support
-- troubleshoot the service
-- comply with legal requirements
+Except as noted below, Microsoft doesn't transfer customer data outside of your selected region. 
 
 If needed, you can transfer your data using preview, beta, or other pre-release services. These services typically store your data in the United States, but may store it globally.
 
 > [!NOTE]
+Microsoft will tranfer you data if it needs to do any of the following actions:
+>- provide customer support
+>- troubleshoot the service
+>- comply with legal requirements
+
+> [!NOTE]
 > Microsoft doesn't control or limit the regions from which you or your users may access your data.
+
+> [!NOTE]
+> Because there's only one region in Brazil, customer data is replicated to south-central United States for disaster recovery and load balancing purposes. For more information, see the [Azure data center map](https://azuredatacentermap.azurewebsites.net/).
+
+> [!NOTE]
+> For builds and releases running on Microsoft-provided macOS agents, your data will be transferred to third party data centers as follows:
+>- US-based users: your data is transferred to a third party US data center
+>- Users from all other countries: your data is transferred to either a third party US data center or European data center
+This data center is owned and managed by a third party with information security certification assurances, such as ISO 27001 and SOC 2 report.
+
 
 ## Related articles
 


### PR DESCRIPTION
Mac hosted builds are run in either the United State or data centers in Europe.

This change attempts to call out all the exceptions to single region in one area.