### PR TITLE
Remove extra WIQL code

### DIFF
--- a/docs/boards/queries/wiql-syntax.md
+++ b/docs/boards/queries/wiql-syntax.md
@@ -41,7 +41,6 @@ FROM WorkItems
 WHERE [Work Item Type] = 'User Story'
 ORDER BY [State] Asc, [Changed Date] Desc
 ASOF '6/15/2010'
-Select [State], [Title]
 ```
 
 The WIQL syntax is not case-sensitive.


### PR DESCRIPTION
I could be wrong, but it appears the WIQL code I removed was a typo. The line had mismatched casing from the rest of the query and appears twice.