### PR TITLE
Update typo in bash.md (Azure Pipelines Task)

### DIFF
--- a/docs/pipelines/tasks/utility/bash.md
+++ b/docs/pipelines/tasks/utility/bash.md
@@ -47,8 +47,8 @@ The Bash task also has a shortcut syntax in YAML:
 |`script`<br/>Script|(Required, if Type is inline) Contents of the script <br/>Default value: `"# Write your commands here\n\necho 'Hello world'\n"`|
 |`workingDirectory`<br/>Working Directory| (Optional) Specify the working directory in which you want to run the command. If you leave it empty, the working directory is [$(Build.SourcesDirectory)](../../build/variables.md)|
 |`failOnStderr`<br/>Fail on standard error|(Optional) If this is true, this task will fail if any errors are written to stderr. <br/>Default value: `true`|
-|`noProfile`<br/>Don't load the system-wide startup/initialization files|(Optional) Don't load the system-wide startup file **`/etc/profile'** or any of the personal initialization files|
-|`noRc`<br/>Don't read the ~/.bashrc file|(Optional) If this is true, the task will not process **`.bashrc`** from the user's home directory.<br/>Default value: true|
+|`noProfile`<br/>Don't load the system-wide startup/initialization files|(Optional) Don't load the system-wide startup file **`/etc/profile`** or any of the personal initialization files|
+|`noRc`<br/>Don't read the ~/.bashrc file|(Optional) If this is true, the task will not process **`.bashrc`** from the user's home directory.<br/>Default value: `true`|
 |`env`<br/>Environment variables| (Optional) A list of additional items to map into the process's environment.<br/>For example, secret variables are not automatically mapped. If you have a secret variable called **`Foo`**, you can map it in like this:
 
 ```YAML


### PR DESCRIPTION
The last row in the `Arguments` table for `env` is not rendering properly [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/bash?view=azure-devops#arguments). It is being added to the right cell of the `noRc` row rather than being given it's own row. I think this backtick fix around `etc/profile` _may_ fix that (can't prove it since GitHub's markdown interpreter gracefully handles it).

Also, added backticks around a default value for consistency.