### PR TITLE
Update resolve-orphaned-organization.md

### DIFF
--- a/docs/organizations/accounts/resolve-orphaned-organization.md
+++ b/docs/organizations/accounts/resolve-orphaned-organization.md
@@ -37,7 +37,7 @@ If you don't know who the Azure DevOps Administrator is for your organization, f
 1. To find your Azure DevOps Administrator, go to the [Azure portal](https://portal.azure.com/), as described in [View and assign administrator roles in Azure Active Directory](/azure/active-directory/users-groups-roles/directory-manage-roles-portal). To learn more about Azure AD roles, see [Administrator role permissions in Azure Active Directory](/azure/active-directory/users-groups-roles/directory-assign-admin-roles).  
 2. The Azure DevOps Administrator can now complete the steps in [Change Azure DevOps owner](change-organization-ownership.md) to claim ownership of the target Azure DevOps organization.  
 
-## When you don't have an Administrator
+## When you don't have an Azure DevOps Administrator
 
 When your Azure AD tenant hasn't assigned an Azure DevOps Administrator, complete the following steps.
 
@@ -47,7 +47,7 @@ When your Azure AD tenant hasn't assigned an Azure DevOps Administrator, complet
 	> [!NOTE]   
 	> Any changes to role membership may take up to an hour to propagate to Azure DevOps.  
 
-3. The Azure DevOps Administrator can now complete the steps in [Change Azure DevOps owner](change-organization-ownership.md) to claim ownership of the target Azure DevOps organization.  
+3. The Azure DevOps Administrator can now complete the steps below to claim ownership of the target Azure DevOps organization.  
  
 ## When your Azure DevOps Administrator isn't a member of the target organization
 


### PR DESCRIPTION
Change 1: Since multiple types of admins are being referenced in this article (PCA, Owner, Azure Global Admin, Privileged Role Admin, Azure DevOps Admin) i think it's better to be clear here 

Change 2:  The Azure DevOps Admin doesn't actually give you the ability to change the org owner in the previously linked doc. Unless the stated Azure DevOps Admin is also a PCA/Org owner, the only way they can take over the org is by following the documentation on this page.