### PR TITLE
Bug in Publish python distribution to Azure Artifacts feed

### DIFF
--- a/docs/pipelines/tasks/package/twine-authenticate.md
+++ b/docs/pipelines/tasks/package/twine-authenticate.md
@@ -61,7 +61,7 @@ In this example, we are setting authentication for publishing to a private Azure
   
 # Use command line script to 'twine upload', use -r to pass the repository name and --config-file to pass the environment variable set by the authenticate task.
 - script: |
-   python -m twine upload -r "myTestProject/myTestFeed" --config-file $(PYPIRC_PATH) dist/*.whl
+   python -m twine upload -r myTestFeed --config-file $(PYPIRC_PATH) dist/*.whl
 ```
 
 The 'artifactFeed' input will contain the project and the feed name if the feed is project scoped. If the feed is organization scoped, only the feed name must be provided. [Learn more](../../../artifacts/feeds/project-scoped-feeds.md).


### PR DESCRIPTION
```
python -m twine upload -r "myTestProject/myTestFeed" --config-file $(PYPIRC_PATH) dist/*.whl
```
gets the error:

```
InvalidConfiguration: Missing 'myTestProject/myTestFeed' section from the configuration file
or not a complete URL in --repository-url.
```
this solves the problem:

```
python -m twine upload -r myTestFeed --config-file $(PYPIRC_PATH) dist/*.whl
```
see full trace https://msdata.visualstudio.com/DefaultCollection/AlgorithmsAndDataScience/_build/results?buildId=10828720&view=logs&j=836bd6c2-066c-5c38-d30d-e81e3a76d869&t=d8543af4-8a21-5f05-1956-5ba398eb8383