### PR TITLE
update java-function.md

### DIFF
--- a/docs/pipelines/ecosystems/java-function.md
+++ b/docs/pipelines/ecosystems/java-function.md
@@ -92,7 +92,7 @@ After the pipeline has run, select the vertical ellipses in the upper-right corn
     azureSubscription: $(serviceConnectionToAzure)
     appType: functionApp
     appName: $(appName)
-    package: $(build.artifactstagingdirectory)/$(appName)
+    package: $(build.artifactstagingdirectory)
 ```
 
 ## Run the pipeline and check out your site


### PR DESCRIPTION
line 95 should not have the /$(appName) in the path, as the  path to publish in previous task does not include it, otherwise, it caues the pipeline to fail.