### PR TITLE
Add Build.SourceBranch since it is also available within a template expression

### DIFF
--- a/docs/pipelines/process/templates.md
+++ b/docs/pipelines/process/templates.md
@@ -505,7 +505,7 @@ steps:
 
 Within a template expression, you have access to the `parameters` context that contains the values of parameters passed in.
 Additionally, you have access to the `variables` context that contains all the variables specified in the YAML file plus 
-the [system variables](../build/variables.md#system-variables). 
+the [system variables](../build/variables.md#system-variables) and `Build.SourceBranch`. 
 Importantly, it doesn't have runtime variables such as those stored on the pipeline or given when you start a run.
 Template expansion happens [very early in the run](runs.md#process-the-pipeline), so those variables aren't available.
 


### PR DESCRIPTION
In testing, I found that I was able to access `Build.SourceBranch` in a template expression by wrapping the variable using this syntax:

`${{ if contains(variables['Build.SourceBranch'],'vNext/') }}` 

I did this in a fit of desperation to try to get a value used by a demand.  See issues #7494 , #7170, #5279 for additional context.