### PR TITLE
Update list of available AZ PowerShell module versions in Azure PowerShell v4 task

### DIFF
--- a/docs/pipelines/tasks/deploy/azure-powershell.md
+++ b/docs/pipelines/tasks/deploy/azure-powershell.md
@@ -65,7 +65,7 @@ Azure PowerShell task uses Azure/AzureRM/Az PowerShell Module to interact with A
 <table><thead><tr><th>Task Version</th><th>Available versions of PowerShell Modules</th></tr></thead>
 <tr><td>2.* </td><td>Choose one from any of the 2 lists:<br>Azure: 2.1.0, 3.8.0, 4.2.1, 5.1.1<br>AzureRM: 2.1.0, 3.8.0, 4.2.1, 5.1.1, 6.7.0</td></tr>
 <tr><td>3.* </td><td>Choose one from any of the 2 lists:<br>Azure: 2.1.0, 3.8.0, 4.2.1, 5.1.1<br>AzureRM: 2.1.0, 3.8.0, 4.2.1, 5.1.1, 6.7.0</td></tr>
-<tr><td>4.*</td><td>Az Module: 1.0.0, 1.6.0, 2.3.2, 2.6.0, 3.1.0</td></tr>
+<tr><td>4.*</td><td>Az Module: 1.0.0, 1.6.0, 2.3.2, 2.6.0, 3.1.0, 3.5.0</td></tr>
 <tr><td>5.* (preview)</td><td>Az Module: 1.0.0, 1.6.0, 2.3.2, 2.6.0, 3.1.0</td></tr>
 </table>
 


### PR DESCRIPTION
This is applicable due to this week's image upgrade that made the Azure PowerShell v4 task use Az 3.5.0