### PR TITLE
Fix missing escape of | in table.

### DIFF
--- a/docs/pipelines/tasks/utility/cache.md
+++ b/docs/pipelines/tasks/utility/cache.md
@@ -32,7 +32,7 @@ None
 
 | Argument | Description |
 |---|---|
-| Key (unique identifier) for the cache | This should be a string that can be segmented using '|'. File paths can be absolute or relative to $(System.DefaultWorkingDirectory). |
+| Key (unique identifier) for the cache | This should be a string that can be segmented using '\|'. File paths can be absolute or relative to $(System.DefaultWorkingDirectory). |
 | Path of the folder to cache | Can be fully qualified or relative to $(System.DefaultWorkingDirectory). Wildcards are not supported. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) are supported. |
 | Cache hit variable | Variable to set to 'true' when the cache is restored (a cache hit), otherwise set to 'false'. |
 | Additional restore key prefixes | Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes. |


### PR DESCRIPTION
Fixes a typo in the Cache task where there is a missing escape in the table for '|'