### PR TITLE
Clarify nuget.exe usage

### DIFF
--- a/docs/pipelines/tasks/package/nuget.md
+++ b/docs/pipelines/tasks/package/nuget.md
@@ -14,7 +14,7 @@ monikerRange: '>= tfs-2018'
 
 [!INCLUDE [version-tfs-2018](../../includes/version-tfs-2018.md)]
 
-Use this task in a build or release pipeline to install and update NuGet package dependencies, or package and publish NuGet packages.
+Use this task in a build or release pipeline to install and update NuGet package dependencies, or package and publish NuGet packages. Uses NuGet.exe and works with .NET Framework apps. For .NET Core and .NET Standard apps, use the .NET Core task.
 
 ::: moniker range="<= tfs-2018"
 


### PR DESCRIPTION
The YAML comment says that the task uses nuget.exe and should be used with .NET Framework projects (although technically this is incorrect, it should be used with non-SDK style projects. SDK style projects can target the .NET Framework, in which case the dotnet cli or msbuild should be used, not nuget.exe. For packing projects, even non-SDK style projects using PackageReference should use msbuild and not nuget.exe). Anyway, that very useful snippet of information is not visible when viewing the page because it's in a code block that is too wide for the page and therefore is hidden unless you scroll to the right.