### PR TITLE
Removed extra s on TestResults EntitySet

### DIFF
--- a/docs/report/extend-analytics/data-model-analytics-service.md
+++ b/docs/report/extend-analytics/data-model-analytics-service.md
@@ -88,7 +88,7 @@ The following EntitySets are only supported with the **v3.0-preview** API versio
 > |TestResultsDaily | A daily snapshot aggregate of TestResult executions, grouped by Test (not TestRun) |  ✔️ |
 > |TestRuns | Execution information for tests run under a pipeline with aggregate TestResult |  ✔️ |
 > |Tests | Properties for a test | ✔️ |
-> |TestsResults | Individual execution results for a specific Test associated with a TestRun |  ✔️ |
+> |TestResults | Individual execution results for a specific Test associated with a TestRun |  ✔️ |
 
 
 


### PR DESCRIPTION
was TestsResults

With Test**s**Results
![image](https://user-images.githubusercontent.com/6670531/77228708-635dba80-6b89-11ea-80b3-65c39853729c.png)

Works without the extra S
![image](https://user-images.githubusercontent.com/6670531/77228694-4f19bd80-6b89-11ea-95fb-f2c21584851b.png)