### PR TITLE
Added missing display name for restore

### DIFF
--- a/docs/pipelines/ecosystems/dotnet-core.md
+++ b/docs/pipelines/ecosystems/dotnet-core.md
@@ -266,6 +266,7 @@ To restore packages from a custom feed, use the **.NET Core** task:
 # do this before your build tasks
 steps:
 - task: DotNetCoreCLI@2
+  displayName: Restore
   inputs:
     command: restore
     projects: '**/*.csproj'


### PR DESCRIPTION
Added display name for DotNetCoreCLI task:
- to be in line with other samples on the same page (consistency)
- as the DotNetCoreCLI task contains multiple actions (and the default display name would just say 'DotNetCoreCLI')