### PR TITLE
Remove non working code block

### DIFF
--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -209,12 +209,6 @@ Using a personal access token (PAT) is a great way to authenticate with Azure De
     Install-Module -Name Get-Hello -Repository PowershellAzureDevopsServices
     ```
 
-If the *Install-Module* command is returning the following error: *Unable to resolve package source*, run the `Register-PackageSource` cmdlet again with the `Trusted` flag as follows:
-
-```powershell
-Register-PackageSource -Name "PowershellAzureDevopsServices" -Location "https://pkgs.dev.azure.com/<ORGANIZATION_NAME>/_packaging/<FEED_NAME>/nuget/v2" -ProviderName NuGet -Trusted -Trusted -SkipValidate -Credential $credsAzureDevopsServices
-```
-
 > [!NOTE]
 > If your organization is using a firewall or a proxy server, make sure you allow [Azure Artifacts Domain URLs and IP addresses](../../organizations/security/allow-list-ip-url.md#azure-artifacts).
 


### PR DESCRIPTION
The removed code block defined the `-Trusted` parameter twice and throws an error. The above code block already has the `-Trusted` parameter set, so there is no need to have this example as a separate block.