### PR TITLE
Update github-advanced-security-code-scanning.md

### DIFF
--- a/docs/repos/security/github-advanced-security-code-scanning.md
+++ b/docs/repos/security/github-advanced-security-code-scanning.md
@@ -35,7 +35,7 @@ CodeQL supports and uses the following language identifiers:
 | C#                     | `csharp`                |                                           |
 | Go                     | `go`                    |                                           |
 | Java/Kotlin            | `java-kotlin`           |                           |
-| JavaScript/TypeScript  | `javascript-typescript` |                  |
+| JavaScript/TypeScript  | `javascript`            |                                           |
 | Python                 | `python`                |                                           |
 | Ruby                   | `ruby`                  |                                           |
 | Swift                  | `swift`                 |                                           |
@@ -43,7 +43,7 @@ CodeQL supports and uses the following language identifiers:
 > [!TIP]
 > * Use `c-cpp` to analyze code written in C, C++ or both.
 > * Use `java-kotlin` to analyze code written in Java, Kotlin or both.
-> * Use `javascript-typescript` to analyze code written in JavaScript, TypeScript or both.
+> * Use `javascript` to analyze code written in JavaScript, TypeScript or both.
 
 For more information, see [Supported languages and frameworks](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/). 
 


### PR DESCRIPTION
Updated the language identifier to javascript and 'javascript-typescript is not a supported identifier:
```
Starting: AdvancedSecurityCodeqlInit
==============================================================================
Task         : Advanced Security Initialize CodeQL
Description  : Initializes the CodeQL database in preparation for building.
Version      : 1.1.283
Author       : Microsoft Corporation
Help         : https://aka.ms/advancedsecurity/code-scanning/detection
==============================================================================
Session Id=4cb217b5-a0ac-46a5-a3b1-2605beaf294a
##[warning] advancedsecurity.codeql.language provided was invalid.  Please ensure the language matches one of the following: csharp,cpp,go,java,javascript,python,ruby,swift
##[error]advancedsecurity.codeql.language provided was invalid.  Please ensure the language matches one of the following: csharp,cpp,go,java,javascript,python,ruby,swift


```