### PR TITLE
iif implementation doesn't support 1 or 2 parameter

### DIFF
--- a/docs/pipelines/process/expressions.md
+++ b/docs/pipelines/process/expressions.md
@@ -332,7 +332,7 @@ Counters are scoped to a pipeline. In other words, its value is incremented for 
 ::: moniker range=">= azure-devops"
 ### iif
 * Returns the second parameter if the first parameter evaluates to `True`, and the third parameter otherwise
-* Min parameters: 1. Max parameters: 3
+* Min parameters: 3. Max parameters: 3
 * The first parameter must be a condition
 * Example: `iif(eq(variables['Build.Reason'], 'PullRequest'), 'ManagedDevOpsPool', 'Azure Pipelines')` returns 'ManagedDevOpsPool' when the pipeline runs in response to a PR.
 ::: moniker-end


### PR DESCRIPTION
Adjust docs to match implementation assuming this is not autogenerated
```yaml
steps:
- ${{ if iif(False, False) }}:
  - bash: ok
```
is a syntax error for the validate pipeline feature

_After I saw the documentation, I thought that 1 or 2 parameters are valid as well and no it didn't work_