### PR TITLE
add Ubuntu 24.04 Dockerfile example

### DIFF
--- a/docs/pipelines/agents/docker.md
+++ b/docs/pipelines/agents/docker.md
@@ -241,6 +241,35 @@ Next, create the Dockerfile.
       ENTRYPOINT [ "./start.sh" ]
       ```
 
+    * For Ubuntu 24.04:
+      ```dockerfile
+      FROM ubuntu:24.04
+      ENV TARGETARCH="linux-x64"
+      # Also can be "linux-arm", "linux-arm64".
+
+      RUN apt update && \
+        apt upgrade -y && \
+        apt install -y curl git jq libicu74
+
+      # Install Azure CLI
+      RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+      WORKDIR /azp/
+
+      COPY ./start.sh ./
+      RUN chmod +x ./start.sh
+
+      # Create agent user and set up home directory
+      RUN useradd -m -d /home/agent agent
+      RUN chown -R agent:agent /azp /home/agent
+
+      USER agent
+      # Another option is to run the agent as root.
+      # ENV AGENT_ALLOW_RUNASROOT="true"
+
+      ENTRYPOINT [ "./start.sh" ]
+      ```
+
     * For Ubuntu 22.04:
       ```dockerfile
       FROM ubuntu:22.04


### PR DESCRIPTION
In this PR https://github.com/MicrosoftDocs/azure-devops-docs/pull/14309, was added compatibility with Ubuntu 24.04, but no example of `Dockerfile` for Ubuntu 24.04 was added. This is important because the version of `libicu70` [is no longer available](https://answers.launchpad.net/ubuntu/+source/icu/+question/818827) but `libicu74` is.