### PR TITLE
Update credential instructions

### DIFF
--- a/docs/artifacts/tutorials/private-powershell-library.md
+++ b/docs/artifacts/tutorials/private-powershell-library.md
@@ -98,7 +98,7 @@ If you don't have your own module, follow the instructions in this section to cr
 
 1. The type of credential object to use depends on which version of Azure DevOps you're on:
 
-    - On Azure DevOps Service (dev.azure.com), run the following command to create the credential object:
+    - On Azure DevOps Services (dev.azure.com), run the following command to create the credential object:
 
         ```powershell
         $credential = Get-Credential


### PR DESCRIPTION
This PR proposes to update the section [Register a repository](https://learn.microsoft.com/en-us/azure/devops/artifacts/tutorials/private-powershell-library?view=azure-devops&pivots=psresourceget#register-a-repository) in the [Use an Azure Artifacts feed as a private PowerShell repository](https://learn.microsoft.com/en-us/azure/devops/artifacts/tutorials/private-powershell-library?view=azure-devops&pivots=psresourceget) article to reflect the changes made in https://github.com/PowerShell/PSResourceGet/pull/1599 to support Personal Access Tokens for Azure DevOps Server.

Additionally, I propose to replace the example code that required pasting the personal access token on the command line, which can leak the token to the history, with a simpler approach based on `Get-Credential` or `Read-Host -AsSecureString`, which instead securely prompts the user for the necessary input.