### PR TITLE
Updating changes to azure devops permissions

### DIFF
--- a/docs/organizations/security/includes/pipelines-build.md
+++ b/docs/organizations/security/includes/pipelines-build.md
@@ -38,7 +38,7 @@ monikerRange: '<= azure-devops'
 | Administer build permissions| | |✔️|✔️| 
 | Create build pipeline| |✔️|✔️|✔️|
 | Delete or edit build pipeline| |✔️|✔️|✔️| 
-| Delete or destroy builds | | |✔️|✔️| 
+| Delete or destroy builds | |✔️|✔️|✔️| 
 |Edit build quality        | |✔️|✔️|✔️| 
 |Manage build qualities    | | |✔️|✔️| 
 |Manage build queue        | | |✔️|✔️| 


### PR DESCRIPTION
Azure devops addes the default permission of allowing Contributors to delete/destroy builds. Updating table to reflect