### PR TITLE
Update reorder test cases section for clarity

### DIFF
--- a/docs/test/create-test-cases.md
+++ b/docs/test/create-test-cases.md
@@ -77,11 +77,7 @@ For more information, see [Test different configurations](test-different-configu
 
 ## Reorder test cases
 
-You can reorder manual test cases in static suites, requirement-based suites, and query-based suites.
-
-Open a test case, and then use the up and down arrows to change the order.
-
-![Screenshot showing the arrows used to move test steps up or down.](media/create-test-cases/change-step-order.png)
+Currently you cannot reorder manual test cases in static suites, requirement-based suites, and query-based suites from the user interface.
 
 ## Add existing test cases to a test suite
 


### PR DESCRIPTION
Clarify that reordering test cases is not possible from the user interface.

The section "Reorder test cases" (https://learn.microsoft.com/en-us/azure/devops/test/create-test-cases?view=azure-devops#reorder-test-cases) is incorrect.

It shows a screenshot of an edit test case screen claiming that the shown up/down buttons change the order of the test case in the suite, but those up/down buttons are for the test steps of the test case and they change the order of test steps not the order of the test case within test suite. (This option would anyway be impossible, because one test case can be included in multiple test suite, so it could not know in which test suite it changes the order).

The question came up, because I do want to change the order of the test cases in a suite, but could not find any way to do it through the UI and I would be interested in finding a way.

But the method described in the documentation is wrong and the proposed change clarifies that.