### PR TITLE
Update IP address instructions for GitHub hosted runners

### DIFF
--- a/docs/pipelines/agents/hosted.md
+++ b/docs/pipelines/agents/hosted.md
@@ -202,7 +202,7 @@ To determine your geography, navigate to `https://dev.azure.com/<your_organizati
 >
 >If your organization is in the **West Europe** region, the capacity fallback geography is **France**.
 >
->Our Mac IP ranges aren't included in the Azure IPs above, as they are hosted in GitHub's macOS cloud. IP ranges can be retrieved using the [GitHub metadata API](https://docs.github.com/en/rest/reference/meta#get-github-meta-information) using the instructions provided [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#ip-addresses).
+>Our Mac IP ranges aren't included in the Azure IPs above, as they are hosted in GitHub's macOS cloud. IP ranges can be retrieved using the [GitHub metadata API](https://docs.github.com/en/rest/reference/meta#get-github-meta-information) using the instructions provided [here](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#ip-addresses).
 
 #### Example
 


### PR DESCRIPTION
Updated the link in Line 205 for "here" where it says "using the instructions provided here" from:

https://docs.github.com/en/actions/concepts/runners/github-hosted-runners#ip-addresses

To 

https://docs.github.com/en/actions/reference/runners/github-hosted-runners#ip-addresses