### PR TITLE
Trivial update to documentation to reflect iteration listing

### DIFF
--- a/docs/organizations/settings/set-iteration-paths-sprints.md
+++ b/docs/organizations/settings/set-iteration-paths-sprints.md
@@ -264,7 +264,7 @@ az boards iteration team list --team
 
 #### Example
 
-For example, the following command lists the iterations for the Service Delivery team. For other output format options, see [Output formats for Azure CLI commands](/cli/azure/format-output-azure-cli)
+For example, the following command lists the iterations for the Service Delivery team. For other output format options, see [Output formats for Azure CLI commands](/cli/azure/format-output-azure-cli).
 
 > [!div class="tabbedCodeSnippets"]
 ```azurecli

--- a/docs/organizations/settings/set-iteration-paths-sprints.md
+++ b/docs/organizations/settings/set-iteration-paths-sprints.md
@@ -264,7 +264,7 @@ az boards iteration team list --team
 
 #### Example
 
-For example, the following command lists the area paths for the Service Delivery team. For other output format options, see [Output formats for Azure CLI commands](/cli/azure/format-output-azure-cli)
+For example, the following command lists the iterations for the Service Delivery team. For other output format options, see [Output formats for Azure CLI commands](/cli/azure/format-output-azure-cli)
 
 > [!div class="tabbedCodeSnippets"]
 ```azurecli


### PR DESCRIPTION
The listing showed iterations but the description said "area paths."