### PR TITLE
Add a note with workaround Azure Artifacts source when packages are m…

### DIFF
--- a/docs/pipelines/release/artifacts.md
+++ b/docs/pipelines/release/artifacts.md
@@ -157,6 +157,12 @@ The following features are available when using Azure Artifacts as an artifact s
 | Work items and commits | Link work items to see them displayed in the release details. Commits will be shown when using Git or TFVC.|
 | [Artifact download](#artifact-download) | By default, pipeline artifacts are downloaded to the agent running the pipeline. You can also configure a step in your stage to [skip downloading](/azure/devops/pipelines/yaml-schema/steps-download) the artifact if needed. |
 
+
+> [!NOTE]
+> When using Feeds with 1000 packages or more, you may see that the packages in Package drop down in Azure Artifacts source may be truncated after certain packages.
+> To work around this issue, create a new Custom View and [promote](https://learn.microsoft.com/en-us/azure/devops/artifacts/feeds/views?view=azure-devops&tabs=nuget%2Cnugetserver22%2Cpowershell) packages to that view. And then in the Release pipeline, specify the View in the Azure Artifact source.
+> Or you can you can provide the package ID, which you can find using the instructions [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/artifacts/artifact-details/get-packages?view=azure-devops-rest-5.0).
+
 #### Handling Maven snapshots
 
 When using Maven snapshots, multiple versions can be downloaded at once (example `myApplication-2.1.0.BUILD-20190920.220048-3.jar`, `myApplication-2.1.0.BUILD-20190820.221046-2.jar`, `myApplication-2.1.0.BUILD-20190820.220331-1.jar`). You might need to remove the old versions and only keep the latest artifact before deployment.

--- a/docs/pipelines/release/artifacts.md
+++ b/docs/pipelines/release/artifacts.md
@@ -159,9 +159,9 @@ The following features are available when using Azure Artifacts as an artifact s
 
 
 > [!NOTE]
-> When using Feeds with 1000 packages or more, you may see that the packages in Package drop down in Azure Artifacts source may be truncated after certain packages.
-> To work around this issue, create a new Custom View and [promote](https://learn.microsoft.com/en-us/azure/devops/artifacts/feeds/views?view=azure-devops&tabs=nuget%2Cnugetserver22%2Cpowershell) packages to that view. And then in the Release pipeline, specify the View in the Azure Artifact source.
-> Or you can you can provide the package ID, which you can find using the instructions [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/artifacts/artifact-details/get-packages?view=azure-devops-rest-5.0).
+> When using a **Feed** with 1,000 packages or more, the packages listed in the **Package** dropdown for the Azure Artifacts source might be truncated.
+> To work around this issue, create a new custom view and [promote](https://learn.microsoft.com/en-us/azure/devops/artifacts/feeds/views?view=azure-devops&tabs=nuget%2Cnugetserver22%2Cpowershell) packages to that view. Then, in the release pipeline, specify the view in the Azure Artifacts source.
+> Alternatively, you can provide the package ID. For instructions, see [Get Packages - Artifact Details](/rest/api/azure/devops/artifacts/artifact-details/get-packages?view=azure-devops-rest-5.0).
 
 #### Handling Maven snapshots
 

--- a/docs/pipelines/release/artifacts.md
+++ b/docs/pipelines/release/artifacts.md
@@ -160,8 +160,8 @@ The following features are available when using Azure Artifacts as an artifact s
 
 > [!NOTE]
 > When using a **Feed** with 1,000 packages or more, the packages listed in the **Package** dropdown for the Azure Artifacts source might be truncated.
-> To work around this issue, create a new custom view and [promote](https://learn.microsoft.com/en-us/azure/devops/artifacts/feeds/views?view=azure-devops&tabs=nuget%2Cnugetserver22%2Cpowershell) packages to that view. Then, in the release pipeline, specify the view in the Azure Artifacts source.
-> Alternatively, you can provide the package ID. For instructions, see [Get Packages - Artifact Details](/rest/api/azure/devops/artifacts/artifact-details/get-packages?view=azure-devops-rest-5.0).
+> To work around this issue, create a new custom view and [promote](../../artifacts/feeds/views.md) packages to that view. Then, in the release pipeline, specify the view in the Azure Artifacts source.
+> Alternatively, you can provide the package ID. For instructions, see [Get Packages - Artifact Details](/rest/api/azure/devops/artifacts/artifact-details/get-packages).
 
 #### Handling Maven snapshots
 


### PR DESCRIPTION
…issing in Package drop down list.

Added notes on handling package truncation in Azure Artifacts source when using Feeds with many packages.

We are getting cases related to this issue since May 2022 or earlier. There was a fix released for more than 15k feeds but the issue is related to number of packages in the feed. Please reach out if you need reference to related bug and IcMs.