### PR TITLE
Update caching-nuget.md with SDK version pinning advice

### DIFF
--- a/docs/pipelines/artifacts/caching-nuget.md
+++ b/docs/pipelines/artifacts/caching-nuget.md
@@ -36,6 +36,9 @@ To lock your project's dependencies, add the **RestorePackagesWithLockFile** pro
 </PropertyGroup>
 ```
 
+> [!NOTE]
+> It's also recommended to pin the version of the .NET SDK that's used so the SDK version and dependency graph stay in lockstep. See [global.json](/dotnet/core/tools/global-json) and especially the `rollForward` section with the `disable` value [global.json rollForward Policy](/dotnet/core/tools/global-json#rollforward). For related issues when not pinning, see [ASP.NET Core GitHub issue](https://github.com/dotnet/aspnetcore/issues/65061) and [.NET Core SDK GitHub issue](https://github.com/dotnet/sdk/issues/48795)
+
 ## Cache NuGet packages
 
 To cache NuGet packages, define a pipeline variable that points to the location of the packages on the agent running the pipeline.

--- a/docs/pipelines/artifacts/caching-nuget.md
+++ b/docs/pipelines/artifacts/caching-nuget.md
@@ -37,7 +37,7 @@ To lock your project's dependencies, add the **RestorePackagesWithLockFile** pro
 ```
 
 > [!NOTE]
-> It's also recommended to pin the version of the .NET SDK that's used so the SDK version and dependency graph stay in lockstep. See [global.json](/dotnet/core/tools/global-json) and especially the `rollForward` section with the `disable` value [global.json rollForward Policy](/dotnet/core/tools/global-json#rollforward). For related issues when not pinning, see [ASP.NET Core GitHub issue](https://github.com/dotnet/aspnetcore/issues/65061) and [.NET Core SDK GitHub issue](https://github.com/dotnet/sdk/issues/48795)
+> If you use package lock files, consider specifying an exact .NET SDK version in a `global.json` file and setting `rollForward` to `disable`. This can help prevent locked restore failures when implicit dependencies vary across .NET SDK versions. For more information, see [.NET SDK global.json](/dotnet/core/tools/global-json).
 
 ## Cache NuGet packages
 


### PR DESCRIPTION
Added recommendation to pin .NET SDK version for consistency.

See comment from Microsoft(Chet) here https://github.com/dotnet/sdk/issues/48795#issuecomment-3001803076
> Our current recommendation for users that use lock files is to also lock their SDK versions via global.json with no rollforward, so they(sic) their entire toolchain stays in lockstep.

Related https://github.com/dotnet/docs/issues/53347

(The docs page doesn't have an easy way to know which page you can contribute to like the .NET pages does would be great if you had the same!
<img width="709" height="268" alt="image" src="https://github.com/user-attachments/assets/21b8d94f-b2eb-42fc-ace7-6b66b7a27d81" />
)