### PR TITLE
Update Enable shell tasks arguments validation task list

### DIFF
--- a/docs/pipelines/security/inputs.md
+++ b/docs/pipelines/security/inputs.md
@@ -119,7 +119,7 @@ A running pipeline can't modify pipeline parameters, unlike variables. Parameter
 
 Pipelines can reference tasks executed within the pipeline. Some tasks include an `arguments` parameter that allows users to specify more options for the task.
 
-Applying the  **Enable shell tasks arguments validation** setting validates `argument` parameters for built-in shell tasks to check for inputs that can inject commands into scripts. The check ensures that the shell correctly executes characters like semicolons, quotes, and parentheses in the following pipeline tasks:
+Applying the  **Enable shell tasks arguments validation** setting validates `arguments` parameters for built-in shell tasks to check for inputs that can inject commands into scripts. The check ensures that the shell correctly executes characters like semicolons, quotes, and parentheses in the following pipeline tasks:
 
 - PowerShell
 - BatchScript

--- a/docs/pipelines/security/inputs.md
+++ b/docs/pipelines/security/inputs.md
@@ -121,21 +121,18 @@ Pipelines can reference tasks executed within the pipeline. Some tasks include a
 
 Applying the  **Enable shell tasks arguments validation** setting validates `argument` parameters for built-in shell tasks to check for inputs that can inject commands into scripts. The check ensures that the shell correctly executes characters like semicolons, quotes, and parentheses in the following pipeline tasks:
 
-- PowerShell (`PowerShell@2`)
-- BatchScript (`BatchScript@1`)
-- Bash (`Bash@3`)
-- Ssh (`Ssh@0`)
-- AzureFileCopy (`AzureFileCopy@1` – `AzureFileCopy@6`)
-- WindowsMachineFileCopy (`WindowsMachineFileCopy@1` – `WindowsMachineFileCopy@2`)
-- PowerShellOnTargetMachines (`PowerShellOnTargetMachines@3`)
-- SqlAzureDacpacDeployment (`SqlAzureDacpacDeployment@1`)
-- SqlDacpacDeploymentOnMachineGroup (`SqlDacpacDeploymentOnMachineGroup@0`)
-- AzureCLI (`AzureCLI@2`, `AzureCLI@3`)
-- AzurePowerShell (`AzurePowerShell@2` – `AzurePowerShell@5`)
-- ServiceFabricPowerShell (`ServiceFabricPowerShell@1`)
-
-> [!NOTE]
-> For tasks added to the list after the original 2023 rollout (PowerShellOnTargetMachines, SqlAzureDacpacDeployment, SqlDacpacDeploymentOnMachineGroup, AzureCLI, AzurePowerShell, ServiceFabricPowerShell), argument sanitization fires only when **both** the org-level **Enable shell tasks arguments validation** setting and a per-task pipeline-level feature flag are enabled. The per-task feature flags are rolled out gradually by Microsoft to avoid regressions for pipelines that opted into the org-level setting before these tasks were onboarded. Customers do not need to take action; the per-task flags are managed centrally.
+- PowerShell
+- BatchScript
+- Bash
+- Ssh
+- AzureFileCopy
+- WindowsMachineFileCopy
+- PowerShellOnTargetMachines
+- SqlAzureDacpacDeployment
+- SqlDacpacDeploymentOnMachineGroup
+- AzureCLI
+- AzurePowerShell
+- ServiceFabricPowerShell
 
 You can apply **Enable shell tasks arguments validation** at the organization level under **Organization Settings** > **Pipelines** > **Settings** or at the project level under **Project settings** > **Pipelines** > **Settings**. If the organization-level setting is enabled, it applies to all projects in the organization and can't be turned off at the project level.
 

--- a/docs/pipelines/security/inputs.md
+++ b/docs/pipelines/security/inputs.md
@@ -1,7 +1,7 @@
 ---
 title: Securely use variables and parameters
 description: Find out how to safely accept input from pipeline users in Azure Pipelines.
-ms.date: 08/15/2025
+ms.date: 05/12/2026
 monikerRange: "<=azure-devops"
 #customer intent: As an Azure Pipeline administrator, I want to understand how to securely accept user input so I can avoid security risks from variable and parameter usage in my pipelines.
 ms.topic: best-practice
@@ -121,12 +121,21 @@ Pipelines can reference tasks executed within the pipeline. Some tasks include a
 
 Applying the  **Enable shell tasks arguments validation** setting validates `argument` parameters for built-in shell tasks to check for inputs that can inject commands into scripts. The check ensures that the shell correctly executes characters like semicolons, quotes, and parentheses in the following pipeline tasks:
 
-- PowerShell 
-- BatchScript
-- Bash 
-- Ssh
-- AzureFileCopy
-- WindowsMachineFileCopy
+- PowerShell (`PowerShell@2`)
+- BatchScript (`BatchScript@1`)
+- Bash (`Bash@3`)
+- Ssh (`Ssh@0`)
+- AzureFileCopy (`AzureFileCopy@1` – `AzureFileCopy@6`)
+- WindowsMachineFileCopy (`WindowsMachineFileCopy@1` – `WindowsMachineFileCopy@2`)
+- PowerShellOnTargetMachines (`PowerShellOnTargetMachines@3`)
+- SqlAzureDacpacDeployment (`SqlAzureDacpacDeployment@1`)
+- SqlDacpacDeploymentOnMachineGroup (`SqlDacpacDeploymentOnMachineGroup@0`)
+- AzureCLI (`AzureCLI@2`, `AzureCLI@3`)
+- AzurePowerShell (`AzurePowerShell@2` – `AzurePowerShell@5`)
+- ServiceFabricPowerShell (`ServiceFabricPowerShell@1`)
+
+> [!NOTE]
+> For tasks added to the list after the original 2023 rollout (PowerShellOnTargetMachines, SqlAzureDacpacDeployment, SqlDacpacDeploymentOnMachineGroup, AzureCLI, AzurePowerShell, ServiceFabricPowerShell), argument sanitization fires only when **both** the org-level **Enable shell tasks arguments validation** setting and a per-task pipeline-level feature flag are enabled. The per-task feature flags are rolled out gradually by Microsoft to avoid regressions for pipelines that opted into the org-level setting before these tasks were onboarded. Customers do not need to take action; the per-task flags are managed centrally.
 
 You can apply **Enable shell tasks arguments validation** at the organization level under **Organization Settings** > **Pipelines** > **Settings** or at the project level under **Project settings** > **Pipelines** > **Settings**. If the organization-level setting is enabled, it applies to all projects in the organization and can't be turned off at the project level.
 


### PR DESCRIPTION
## Summary

Refreshes the **Enable shell tasks arguments validation** task list under [Securely use pipeline variables and parameters](https://learn.microsoft.com/azure/devops/pipelines/security/inputs#enable-shell-tasks-arguments-validation).

The list was last updated in September 2023 (commit 6cab6dc by @merlynomsft) when the original sanitizer shipped for `PowerShell`, `Bash`, `Ssh`, `AzureFileCopy`, and `WindowsMachineFileCopy`. Since then the sanitizer was extended in `microsoft/azure-pipelines-tasks` to six additional task families but the docs were never updated:

- `PowerShellOnTargetMachines`
- `SqlAzureDacpacDeployment`
- `SqlDacpacDeploymentOnMachineGroup`
- `AzureCLI`
- `AzurePowerShell`
- `ServiceFabricPowerShell`

## Changes

The six task family names above are appended to the existing bulleted list. No other changes, no version annotations, no implementation detail. Style matches the original 2023 entries.