### PR TITLE
Clarify push protection behavior for existing repositories

### DIFF
--- a/docs/repos/security/configure-github-advanced-security-features.md
+++ b/docs/repos/security/configure-github-advanced-security-features.md
@@ -148,6 +148,11 @@ Secret scanning push protection and repository scanning are automatically enable
 :::image type="content" source="media/adv-sec-repository-settings-secret-protection-options.png" lightbox="media/adv-sec-repository-settings-secret-protection-options.png" alt-text="Screenshot of enabling push protection.":::
 
 Secret scanning repository scanning is automatically kicked off upon enabling Secret Protection for a selected repository. 
+
+> [!NOTE]
+> Push protection evaluates only pushes that occur after the feature is enabled for the repository and does not retroactively block existing commits or repository history.
+> However, repository secret scanning can still detect secrets already present in the repository, including historical commits.
+
 :::zone-end
 
 ## Set up dependency scanning


### PR DESCRIPTION
### Summary
Adds a clarification note to the "Set up secret scanning" section explaining the difference between repository secret scanning and push protection behaviour for existing repositories.

### Details
The added note clarifies that:
- Push protection evaluates only pushes that occur after the feature is enabled.
- Existing commits and repository history aren't retroactively blocked.
- Repository secret scanning can still detect secrets already present in the repository, including historical commits.

This helps clarify onboarding expectations for users enabling GitHub Advanced Security on repositories that existed before enablement.

### Reason for change 
The current documentation explains repository scanning and push protection separately, but it may not be immediately clear that push protection applies only to future pushes while repository scanning can detect historical secrets. This clarification helps reduce confusion during setup and adoption.