### PR TITLE
Trivial updates to referencing "resolved" states

### DIFF
--- a/docs/boards/queries/query-by-workflow-changes.md
+++ b/docs/boards/queries/query-by-workflow-changes.md
@@ -594,7 +594,7 @@ For more information about field attributes, see [Work item fields and attribute
       The name of the team member who changed the status of a work item to a *Resolved* category state. 
       ::: moniker-end 
       ::: moniker range="< azure-devops"
-      The name of the team member who changed the status of a work item to *Resolved* or done workflow state. 
+      The name of the team member who changed the status of a work item to a *Resolved* or done workflow state. 
       ::: moniker-end 
       Reference name=`Microsoft.VSTS.Common.ResolvedBy`, Data type=String (Identity)
    :::column-end:::
@@ -613,7 +613,7 @@ For more information about field attributes, see [Work item fields and attribute
    :::column-end:::
    :::column span="2":::
       ::: moniker range="azure-devops"
-      The date and time when the work item was changed to an *In Resolved* category state. 
+      The date and time when the work item was changed to a *Resolved* category state. 
       ::: moniker-end 
       ::: moniker range="< azure-devops"
       The date and time when the work item was moved into a *Resolved* or done workflow state. 


### PR DESCRIPTION
There were some minor typos when referring to "resolved" states, possibly from copy/pasting "In Progress" and only partially correcting after paste.