### PR TITLE
Remove preview note from Actual Result doc (now GA)

### DIFF
--- a/docs/test/actual-result.md
+++ b/docs/test/actual-result.md
@@ -15,10 +15,6 @@ ms.date: 04/13/2026
 
 [!INCLUDE [version-eq-azure-devops](../includes/version-eq-azure-devops.md)]
 
-> [!IMPORTANT]
-> This capability is in **preview**. Functionality might change or be discontinued without notice. Preview capabilities have no Service Level Agreement (SLA) and limited support.
-> If this capability isn't yet available in your organization, wait a few days as it rolls out gradually.
-
 Use the **Actual Result** field in Azure Test Plans to record the execution outcome for each test step during manual test runs in the web runner.
 
 You enable the Actual Result field at the test plan level, and all suites and test cases inherit the setting. This supports different ways of working across teams that share the same organization. Actual Result data is retained as long as test run data, based on your existing retention policies.


### PR DESCRIPTION
The Actual Result feature for manual testing in Azure Test Plans is now Generally Available. This PR removes the preview `> [!IMPORTANT]` note from `docs/test/actual-result.md`, since the capability is no longer in preview and is now backed by a Service Level Agreement (SLA) and full support.

## Change
- Removed the preview disclaimer block stating the capability is in preview, has no SLA, and rolls out gradually.

No other content changed.