### PR TITLE
Fix unrendered mx-imgBorder div

### DIFF
--- a/docs/repos/git/set-git-repository-permissions.md
+++ b/docs/repos/git/set-git-repository-permissions.md
@@ -140,8 +140,8 @@ The permission changes are automatically saved for the selected group.
 
 To enable or disable inheritance for a specific repository, select the repository and then move the **Inheritance** slider to either the on or off position.
 
-[!div class="mx-imgBorder"] 
-![Screenshot that shows enabling or disabling Inheritance for a specific repository.](media/git-permissions/disable-inheritance-specific-repo.png)
+> [!div class="mx-imgBorder"]
+> ![Screenshot that shows enabling or disabling Inheritance for a specific repository.](media/git-permissions/disable-inheritance-specific-repo.png)
 
 To learn about inheritance, see [About permissions and groups](../../organizations/security/about-permissions.md#permission-inheritance).
 


### PR DESCRIPTION
Fixes the `[!div class="mx-imgBorder"]` markup leaking into the rendered page in the "Enable or disable inheritance for a specific repository" section of Set Git repository permissions.

Problem: The `[!div]` extension and its image were missing the blockquote (`>`) prefix, so DocFX didn't parse them as an extension and rendered `[!div class="mx-imgBorder"]` as literal text next to the screenshot.

Fix: Added the `>` prefix to both the `[!div]` line and the image line so they form a single blockquote, matching the correctly rendered usage in the "Set permissions for a specific user" section of the same file.