### PR TITLE
Fix variable reference for agent IP in key vault access

### DIFF
--- a/docs/pipelines/release/key-vault-access.md
+++ b/docs/pipelines/release/key-vault-access.md
@@ -263,7 +263,7 @@ In this approach, the pipeline queries the Microsoft-hosted agent IP at startup,
     Inline: |
      $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
      Add-AzKeyVaultNetworkRule -VaultName "YOUR_KEY_VAULT_NAME" -ResourceGroupName "YOUR_RESOURCE_GROUP_NAME" -IpAddressRange $ip
-     echo "##vso[task.setvariable variable=agentIP]ip"
+     echo "##vso[task.setvariable variable=agentIP]$ip"
     
 - task: AzureKeyVault@2
   inputs:
@@ -279,7 +279,7 @@ In this approach, the pipeline queries the Microsoft-hosted agent IP at startup,
     azurePowerShellVersion: LatestVersion
     ScriptType: InlineScript
     Inline: |
-     $ipRange = $env:agentIP + "/32"
+     $ipRange = "$(agentIP)/32"
      Remove-AzKeyVaultNetworkRule -VaultName "YOUR_KEY_VAULT_NAME" -IpAddressRange $ipRange
   condition: succeededOrFailed()
 ```


### PR DESCRIPTION
The sample currently sets the agentIP variable incorrectly:

```echo "##vso[task.setvariable variable=agentIP]ip"```

This stores the literal string ip instead of the value of $ip. As a result, the later Remove-AzKeyVaultNetworkRule step cannot remove the rule that was added, leaving the agent IP in the Key Vault network rules.

The sample should only use:

```echo "##vso[task.setvariable variable=agentIP]$ip"```

Likewise, the removal step should reference the pipeline variable:

```$ipRange = "$(agentIP)/32"```

This ensures the example works end-to-end.