### PR TITLE
Report invalid domain names in Azure DevOps production environment

### DIFF
--- a/docs/organizations/security/allow-list-ip-url.md
+++ b/docs/organizations/security/allow-list-ip-url.md
@@ -261,14 +261,6 @@ The following URL is required if you're migrating from Azure DevOps Server to th
 https://dataimport.dev.azure.com
 ```
 
-> [!NOTE]
-> Azure DevOps uses Content Delivery Networks (CDNs) to serve static content. Users in **China** should also add the following domain URLs to an allowlist:
->
-> ``` NuGetDomainURLs
-> https://*.vsassetscdn.azure.cn
-> https://*.gallerycdn.azure.cn
-> ```
-
 We recommend you open port `443` to all traffic on the following IP addresses and domains. We also recommend you open port `22` to a smaller subset of targeted IP addresses.
 
 **Port configuration summary:**


### PR DESCRIPTION
The domains vsassetscdn.azure.cn and gallerycdn.azure.cn are not valid domain names. Nevertheless, they are still utilized in the production environment of Azure DevOps and DevOps Marketplace. Kindly report this issue to the corresponding team to implement fixes.