### PR TITLE
! -- update `PublishCodeCoverageResults@2` references to drop `@1`

### DIFF
--- a/docs/pipelines/customize-pipeline.md
+++ b/docs/pipelines/customize-pipeline.md
@@ -96,7 +96,6 @@ You can add more **scripts** or **tasks** as steps to your pipeline. A task is a
     - task: PublishCodeCoverageResults@2
       inputs:
         summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/site/jacoco/jacoco.xml" # Path to summary files
-        reportDirectory: "$(System.DefaultWorkingDirectory)/**/site/jacoco" # Path to report directory
         failIfCoverageEmpty: true # Fail if code coverage results are missing
     ```
     

--- a/docs/pipelines/ecosystems/customize-javascript.md
+++ b/docs/pipelines/ecosystems/customize-javascript.md
@@ -548,7 +548,7 @@ To publish JUnit or xUnit test results to the server, add the [Publish test resu
 To publish code coverage results to the server, add the [Publish code coverage results](/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v1) task. You can find coverage metrics in the build summary, and you can download HTML reports for further analysis.
 
 ```yaml
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   inputs: 
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/*coverage.xml'
 ```

--- a/docs/pipelines/ecosystems/customize-javascript.md
+++ b/docs/pipelines/ecosystems/customize-javascript.md
@@ -253,7 +253,7 @@ To publish test results, use the [Publish test results](/azure/devops/pipelines/
 
 ### Publish code coverage results
 
-If your test scripts run a code coverage tool such as [Istanbul](https://github.com/istanbuljs), add the [Publish code coverage results](/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v1) task. You can then see coverage metrics in the build summary and download HTML reports for further analysis.
+If your test scripts run a code coverage tool such as [Istanbul](https://github.com/istanbuljs), add the [Publish code coverage results](/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2) task. You can then see coverage metrics in the build summary and download HTML reports for further analysis.
 
 The task expects Cobertura or JaCoCo reporting output. Ensure that your code coverage tool runs with the necessary options to generate the right output, for example `--report cobertura`.
 
@@ -545,7 +545,7 @@ To publish JUnit or xUnit test results to the server, add the [Publish test resu
     testRunTitle: 'Test results for JavaScript using gulp'
 ```
 
-To publish code coverage results to the server, add the [Publish code coverage results](/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v1) task. You can find coverage metrics in the build summary, and you can download HTML reports for further analysis.
+To publish code coverage results to the server, add the [Publish code coverage results](/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2) task. You can find coverage metrics in the build summary, and you can download HTML reports for further analysis.
 
 ```yaml
 - task: PublishCodeCoverageResults@2

--- a/docs/pipelines/ecosystems/customize-javascript.md
+++ b/docs/pipelines/ecosystems/customize-javascript.md
@@ -550,9 +550,7 @@ To publish code coverage results to the server, add the [Publish code coverage r
 ```yaml
 - task: PublishCodeCoverageResults@1
   inputs: 
-    codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/*coverage.xml'
-    reportDirectory: '$(System.DefaultWorkingDirectory)/**/coverage'
 ```
 
 #### [Classic](#tab/classic)

--- a/docs/pipelines/ecosystems/customize-python.md
+++ b/docs/pipelines/ecosystems/customize-python.md
@@ -190,7 +190,6 @@ Add the [Publish code coverage results task](/azure/devops/pipelines/tasks/refer
 ```yaml
 - task: PublishCodeCoverageResults@2
   inputs:
-    codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
 ```
 

--- a/docs/pipelines/ecosystems/dotnet-core.md
+++ b/docs/pipelines/ecosystems/dotnet-core.md
@@ -694,7 +694,6 @@ To run tests and publish code coverage with Coverlet:
   - task: PublishCodeCoverageResults@2
     displayName: 'Publish code coverage report'
     inputs:
-      codeCoverageTool: 'Cobertura'
       summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
   ```
 

--- a/docs/pipelines/ecosystems/ruby.md
+++ b/docs/pipelines/ecosystems/ruby.md
@@ -138,9 +138,7 @@ Add the [Publish Code Coverage Results](/azure/devops/pipelines/tasks/reference/
 ```yaml
 - task: PublishCodeCoverageResults@2
   inputs:
-    codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-    reportDirectory: '$(System.DefaultWorkingDirectory)/**/coverage'
     failIfCoverageEmpty: true 
 ```
 
@@ -190,9 +188,7 @@ steps:
 
 - task: PublishCodeCoverageResults@2
   inputs:
-    codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-    reportDirectory: '$(System.DefaultWorkingDirectory)/**/coverage'
     failIfCoverageEmpty: true
   displayName: 'Publish code coverage'
 ```


### PR DESCRIPTION
Updates to ensure that `PublishCodeCoverageResults@2` doesn't reference v1 parameters. Not sure if the surrounding text needs adjusting as well; but this seems pretty solid so far.